### PR TITLE
Make outputFile optional for tileset2sqlite

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -188,7 +188,7 @@ node ./bin/3d-tiles-tools.js tileset2sqlite3 -i ./tileset/ -o ./output/tileset.3
 | Flag | Description | Required |
 | ---- | ----------- | -------- |
 |`-i`, `--input`| Input directory of the tileset. | :white_check_mark: Yes |
-|`-o`, `--output`| Output path of the resulting `.3dtiles` | :white_check_mark: Yes |
+|`-o`, `--output`| Output path of the resulting `.3dtiles` | No |
 |`-f`, `--force`| Overwrite output file if it exists. | No, default `false` |
 
 ## Pipeline

--- a/tools/bin/3d-tiles-tools.js
+++ b/tools/bin/3d-tiles-tools.js
@@ -137,8 +137,7 @@ if (command === 'pipeline') {
 } else if (command === 'cmptToGlb') {
     readCmptWriteGlb(input, output, force);
 } else if (command === 'tileset2sqlite3') {
-    // tileset2sqlite3 is not a pipeline tool, so handle it separately.
-    tileset2sqlite3(input, output, force);
+    tilesetToSqlite3(input, output, force);
 } else {
     processStage(input, force, command, argv)
         .then(function() {
@@ -241,6 +240,19 @@ function directoryExists(directory) {
                 throw err;
             }
             return false;
+        });
+}
+
+function tilesetToSqlite3(inputDirectory, outputPath, force) {
+    outputPath = path.normalize(defaultValue(outputPath,
+        path.join(path.dirname(inputDirectory), path.basename(inputDirectory) + '.3dtiles')));
+    return fileExists(outputPath)
+        .then(function(exists) {
+            if (!force && exists) {
+                console.log('File ' + outputPath + ' already exists. Specify -f or --force to overwrite existing file.');
+                return;
+            }
+            return tileset2sqlite3(inputDirectory, outputPath);
         });
 }
 

--- a/tools/lib/tileset2sqlite3.js
+++ b/tools/lib/tileset2sqlite3.js
@@ -2,15 +2,16 @@
 'use strict';
 
 var Cesium = require('cesium');
-var fs = require('fs');
 var fsExtra = require('fs-extra');
 var path = require('path');
 var Promise = require('bluebird');
 var sqlite3 = require('sqlite3');
 var zlib = require('zlib');
+var fileExists = require('../lib/fileExists');
 var isGzipped = require('../lib/isGzipped');
 
-var fsReadFile = Promise.promisify(fs.readFile);
+var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
+var fsExtraRemove = Promise.promisify(fsExtra.remove);
 
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
@@ -18,75 +19,73 @@ var DeveloperError = Cesium.DeveloperError;
 
 module.exports = tileset2sqlite3;
 
-function tileset2sqlite3(inputDirectory, outputFile, force) {
+function tileset2sqlite3(inputDirectory, outputFile) {
     if (!defined(inputDirectory)) {
         throw new DeveloperError('inputDirectory is required.');
     }
-    if (!defined(outputFile)) {
-        throw new DeveloperError('outputFile is required.');
-    }
 
-    force = defaultValue(force, false);
+    outputFile = defaultValue(outputFile,
+        path.join(path.dirname(inputDirectory), path.basename(inputDirectory) + '.3dtiles'));
 
-    if (!/\.3dtiles$/.test(outputFile)) {
-        outputFile += '.3dtiles';
-    }
-
-    if (!force && fs.existsSync(outputFile)) {
-        console.log('\nRefusing to overwrite existing database.');
-        return;
-    }
-
-    //Create the database.
-    var db = new sqlite3.Database(outputFile, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE);
-    var dbRun = Promise.promisify(db.run, {context : db});
-
-    //Disable journaling and create the table.
-    return dbRun("PRAGMA journal_mode=off;")
-        .then(function() {
-            return dbRun('BEGIN');
+    return fileExists(outputFile)
+        .then(function(exists) {
+            if (exists) {
+                // Delete the .3dtiles file if it already exists
+                return fsExtraRemove(outputFile);
+            }
         })
         .then(function() {
-            return dbRun("CREATE TABLE media (key TEXT PRIMARY KEY, content BLOB)");
-        })
-        .then(function() {
-            //Build the collection of file paths to be inserted.
-            var filepaths = [];
-            var stream = fsExtra.walk(inputDirectory);
-            stream.on('readable', function() {
-                var filePath = stream.read();
-                while (defined(filePath)) {
-                    if (filePath.stats.isFile()) {
-                        filepaths.push(filePath.path);
-                    }
-                    filePath = stream.read();
-                }
-            });
+            // Create the database.
+            var db = new sqlite3.Database(outputFile, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE);
+            var dbRun = Promise.promisify(db.run, {context : db});
 
-            return new Promise(function(resolve, reject) {
-                stream.on('error', reject);
-                stream.on('end', resolve);
-            }).thenReturn(filepaths);
-        })
-        .then(function(filepaths) {
-            return Promise.map(filepaths, function(filepath) {
-                return fsReadFile(filepath)
-                    .then(function(data) {
-                        filepath = path.normalize(path.relative(inputDirectory, filepath)).replace(/\\/g, '/');
-                        if (!isGzipped(data)) {
-                            data = zlib.gzipSync(data);
+            // Disable journaling and create the table.
+            return dbRun('PRAGMA journal_mode=off;')
+                .then(function() {
+                    return dbRun('BEGIN');
+                })
+                .then(function() {
+                    return dbRun('CREATE TABLE media (key TEXT PRIMARY KEY, content BLOB)');
+                })
+                .then(function() {
+                    //Build the collection of file paths to be inserted.
+                    var filepaths = [];
+                    var stream = fsExtra.walk(inputDirectory);
+                    stream.on('readable', function() {
+                        var filePath = stream.read();
+                        while (defined(filePath)) {
+                            if (filePath.stats.isFile()) {
+                                filepaths.push(filePath.path);
+                            }
+                            filePath = stream.read();
                         }
-                        return dbRun("INSERT INTO media VALUES (?, ?)", [filepath, data]);
                     });
-            }, {concurrency : 100});
-        })
-        .then(function() {
-            return dbRun('COMMIT');
-        })
-        .catch(function(error) {
-            console.log(error);
-        })
-        .finally(function() {
-            db.close();
+
+                    return new Promise(function(resolve, reject) {
+                        stream.on('error', reject);
+                        stream.on('end', resolve);
+                    }).thenReturn(filepaths);
+                })
+                .then(function(filepaths) {
+                    return Promise.map(filepaths, function(filepath) {
+                        return fsExtraReadFile(filepath)
+                            .then(function(data) {
+                                filepath = path.normalize(path.relative(inputDirectory, filepath)).replace(/\\/g, '/');
+                                if (!isGzipped(data)) {
+                                    data = zlib.gzipSync(data);
+                                }
+                                return dbRun('INSERT INTO media VALUES (?, ?)', [filepath, data]);
+                            });
+                    }, {concurrency : 100});
+                })
+                .then(function() {
+                    return dbRun('COMMIT');
+                })
+                .catch(function(error) {
+                    console.log(error);
+                })
+                .finally(function() {
+                    db.close();
+                });
         });
 }

--- a/tools/specs/lib/tileset2sqlite3Spec.js
+++ b/tools/specs/lib/tileset2sqlite3Spec.js
@@ -64,9 +64,13 @@ describe('tileset2sqlite3', function() {
         }).toThrowError('inputDirectory is required.');
     });
 
-    it('throws an error if no output file is provided', function() {
-        expect(function() {
-            tileset2sqlite3(inputDirectory, undefined);
-        }).toThrowError('outputFile is required.');
+    it('works when no output file is provided', function(done) {
+        expect(tileset2sqlite3(inputDirectory)
+            .then(function() {
+                return fileExists(outputFile)
+                    .then(function(exists) {
+                        expect(exists).toBe(true);
+                    });
+            }), done).toResolve();
     });
 });


### PR DESCRIPTION
To be consistent with the other tools the output file is now optional for tileset2sqlite.

This also fixes an error if the .3dtiles file already exists and -f is set, in which case it opens the existing database and tries to write to it. I just delete the file if it exists.

None of the code after `// Create the database.` has changed, just indented.
