### PR TITLE
Clean up 3d-tiles-tools.js

### DIFF
--- a/tools/lib/directoryExists.js
+++ b/tools/lib/directoryExists.js
@@ -1,0 +1,24 @@
+'use strict';
+var Promise = require('bluebird');
+var fsExtra = require('fs-extra');
+var fsStat = Promise.promisify(fsExtra.stat);
+
+module.exports = directoryExists;
+
+/**
+ * @private
+ */
+function directoryExists(directory) {
+    return fsStat(directory)
+        .then(function(stats) {
+            return stats.isDirectory();
+        })
+        .catch(function(err) {
+            // If the directory doesn't exist the error code is ENOENT.
+            // Otherwise something else went wrong - permission issues, etc.
+            if (err.code !== 'ENOENT') {
+                throw err;
+            }
+            return false;
+        });
+}


### PR DESCRIPTION
Just some cleanup in the 3d-tiles-tools.js file. The one breaking change is removing the `-z` option for `optimizeB3dm` to gzip the b3dm. Instead it will gzip automatically if the input file is gzipped.