### PR TITLE
Update npm dependencies

### DIFF
--- a/generator/bin/3d-tiles-generator.js
+++ b/generator/bin/3d-tiles-generator.js
@@ -18,9 +18,6 @@ var saveTile = require('../lib/saveTile');
 var saveTilesetJson = require('../lib/saveTilesetJson');
 var util = require('../lib/utility');
 
-var fsExtraCopy = Promise.promisify(fsExtra.copy);
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-
 var Cartesian3 = Cesium.Cartesian3;
 var CesiumMath = Cesium.Math;
 var clone = Cesium.clone;
@@ -845,7 +842,7 @@ function saveInstancedTileset(tilesetName, tileOptions, tilesetOptions) {
             ];
             if (tileOptions.embed === false) {
                 var copyPath = path.join(tilesetDirectory, path.basename(tileOptions.url));
-                promises.push(fsExtraCopy(tileOptions.url, copyPath));
+                promises.push(fsExtra.copy(tileOptions.url, copyPath));
             }
             return Promise.all(promises);
         });
@@ -1369,7 +1366,7 @@ function createTilesetWithExternalResources() {
         }
     };
 
-    return fsExtraReadFile(glbPath)
+    return fsExtra.readFile(glbPath)
         .then(function(glb) {
             var tiles = [
                 createB3dm({
@@ -1407,7 +1404,7 @@ function createTilesetWithExternalResources() {
             return Promise.all([
                 saveTilesetJson(tilesetPath, tilesetJson, prettyJson),
                 saveTilesetJson(tileset2Path, tileset2Json, prettyJson),
-                fsExtraCopy(glbBasePath, glbCopyPath)
+                fsExtra.copy(glbBasePath, glbCopyPath)
             ]);
         });
 }
@@ -2125,7 +2122,7 @@ function createDiscreteLOD() {
     };
 
     var tilesPromise = Promise.map(glbPaths, function(glbPath, index) {
-        return fsExtraReadFile(glbPath)
+        return fsExtra.readFile(glbPath)
             .then(function(glb) {
                 var b3dm = createB3dm({
                     glb : glb
@@ -2381,7 +2378,7 @@ function createRequestVolume() {
             });
     });
 
-    var buildingPromise = fsExtraReadFile(buildingGlbPath)
+    var buildingPromise = fsExtra.readFile(buildingGlbPath)
         .then(function(glb) {
             return createB3dm({
                 glb : glb

--- a/generator/lib/createBatchTableHierarchy.js
+++ b/generator/lib/createBatchTableHierarchy.js
@@ -13,8 +13,6 @@ var Mesh = require('./Mesh');
 var saveTile = require('./saveTile');
 var saveTilesetJson = require('./saveTilesetJson');
 
-var fsExtraReadJson = Promise.promisify(fsExtra.readJson);
-
 var Cartesian3 = Cesium.Cartesian3;
 var CesiumMath = Cesium.Math;
 var defaultValue = Cesium.defaultValue;
@@ -121,7 +119,7 @@ function createBatchTableHierarchy(options) {
     };
 
     return Promise.map(urls, function(url) {
-        return fsExtraReadJson(url)
+        return fsExtra.readJson(url)
             .then(function(gltf) {
                 return Mesh.fromGltf(gltf);
             });

--- a/generator/lib/createGltf.js
+++ b/generator/lib/createGltf.js
@@ -6,8 +6,6 @@ var mime = require('mime');
 var path = require('path');
 var Promise = require('bluebird');
 
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-
 var Cartesian3 = Cesium.Cartesian3;
 var combine = Cesium.combine;
 var defaultValue = Cesium.defaultValue;
@@ -341,7 +339,7 @@ function getLoadImageFunction(image) {
     return function() {
         var imagePath = image.uri;
         var extension = path.extname(imagePath);
-        return fsExtraReadFile(imagePath)
+        return fsExtra.readFile(imagePath)
             .then(function(buffer) {
                 image.uri = 'data:' + mime.lookup(extension) + ';base64,' + buffer.toString('base64');
             });

--- a/generator/lib/createInstancesTile.js
+++ b/generator/lib/createInstancesTile.js
@@ -2,11 +2,8 @@
 var Cesium = require('cesium');
 var fsExtra = require('fs-extra');
 var path = require('path');
-var Promise = require('bluebird');
 var createI3dm = require('./createI3dm');
 var optimizeGltf = require('./optimizeGltf');
-
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
 
 var AttributeCompression = Cesium.AttributeCompression;
 var Cartesian2 = Cesium.Cartesian2;
@@ -147,7 +144,7 @@ function createInstancesTile(options) {
         preserve : true
     };
 
-    return fsExtraReadFile(url)
+    return fsExtra.readFile(url)
         .then(function(glb) {
             return optimizeGltf(glb, gltfOptions);
         })

--- a/generator/lib/saveTile.js
+++ b/generator/lib/saveTile.js
@@ -1,10 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var fsExtra = require('fs-extra');
-var Promise = require('bluebird');
 var zlib = require('zlib');
-
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
 
 var defaultValue = Cesium.defaultValue;
 
@@ -24,5 +21,5 @@ function saveTile(path, contents, gzip) {
     if (gzip) {
         contents = zlib.gzipSync(contents);
     }
-    return fsExtraOutputFile(path, contents);
+    return fsExtra.outputFile(path, contents);
 }

--- a/generator/lib/saveTilesetJson.js
+++ b/generator/lib/saveTilesetJson.js
@@ -1,9 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
 var fsExtra = require('fs-extra');
-var Promise = require('bluebird');
-
-var fsExtraOutputJson = Promise.promisify(fsExtra.outputJson);
 
 var defaultValue = Cesium.defaultValue;
 
@@ -24,5 +21,5 @@ function saveTilesetJson(path, json, prettyJson) {
     if (prettyJson) {
         options.spaces = 2;
     }
-    return fsExtraOutputJson(path, json, options);
+    return fsExtra.outputJson(path, json, options);
 }

--- a/generator/package.json
+++ b/generator/package.json
@@ -23,22 +23,22 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.4.7",
-    "cesium": "^1.29",
-    "fs-extra": "^2.0.0",
-    "gltf-pipeline": "^0.1.0-alpha11",
-    "mime": "^1.3.4",
+    "bluebird": "^3.5.0",
+    "cesium": "^1.33",
+    "fs-extra": "^3.0.1",
+    "gltf-pipeline": "^0.1.0-alpha14",
+    "mime": "^1.3.6",
     "simplex-noise": "^2.3.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.4",
-    "jasmine": "^2.5.2",
-    "jasmine-spec-reporter": "^3.0.0",
+    "jasmine": "^2.6.0",
+    "jasmine-spec-reporter": "^4.1.0",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",
-    "requirejs": "^2.3.2",
-    "yargs": "^6.6.0"
+    "requirejs": "^2.3.3",
+    "yargs": "^8.0.1"
   },
   "scripts": {
     "jsHint": "gulp jsHint",

--- a/tools/bin/3d-tiles-tools.js
+++ b/tools/bin/3d-tiles-tools.js
@@ -22,9 +22,6 @@ var optimizeGlb = require('../lib/optimizeGlb');
 var runPipeline = require('../lib/runPipeline');
 var tilesetToDatabase = require('../lib/tilesetToDatabase');
 
-var fsExtraReadJson = Promise.promisify(fsExtra.readJson);
-var fsReadFile = Promise.promisify(fsExtra.readFile);
-var fsWriteFile = Promise.promisify(fsExtra.outputFile);
 var zlibGunzip = Promise.promisify(zlib.gunzip);
 var zlibGzip = Promise.promisify(zlib.gzip);
 
@@ -189,7 +186,7 @@ function checkFileOverwritable(file, force) {
 }
 
 function readFile(file) {
-    return fsReadFile(file)
+    return fsExtra.readFile(file)
         .then(function(fileBuffer) {
             if (isGzipped(fileBuffer)) {
                 return zlibGunzip(fileBuffer);
@@ -203,7 +200,7 @@ function logCallback(message) {
 }
 
 function processPipeline(inputFile) {
-    return fsExtraReadJson(inputFile)
+    return fsExtra.readJson(inputFile)
         .then(function(pipeline) {
             var inputDirectory = pipeline.input;
             var outputDirectory = pipeline.output;
@@ -290,7 +287,7 @@ function readGlbWriteB3dm(inputPath, outputPath, force) {
                     var featureTableJson = {
                         BATCH_LENGTH : 0
                     };
-                    return fsWriteFile(outputPath, glbToB3dm(glb, featureTableJson));
+                    return fsExtra.outputFile(outputPath, glbToB3dm(glb, featureTableJson));
                 });
         });
 }
@@ -311,7 +308,7 @@ function readGlbWriteI3dm(inputPath, outputPath, force) {
                     var featureTableJsonBuffer = getJsonBufferPadded(featureTable);
                     var featureTableBinaryBuffer = getBufferPadded(Buffer.alloc(12, 0)); // [0, 0, 0]
 
-                    return fsWriteFile(outputPath, glbToI3dm(glb, featureTableJsonBuffer, featureTableBinaryBuffer));
+                    return fsExtra.outputFile(outputPath, glbToI3dm(glb, featureTableJsonBuffer, featureTableBinaryBuffer));
                 });
         });
 }
@@ -323,7 +320,7 @@ function readB3dmWriteGlb(inputPath, outputPath, force) {
             return readFile(inputPath);
         })
         .then(function(b3dm) {
-            return fsWriteFile(outputPath, extractB3dm(b3dm).glb);
+            return fsExtra.outputFile(outputPath, extractB3dm(b3dm).glb);
         });
 }
 
@@ -334,7 +331,7 @@ function readI3dmWriteGlb(inputPath, outputPath, force) {
             return readFile(inputPath);
         })
         .then(function(i3dm) {
-            return fsWriteFile(outputPath, extractI3dm(i3dm).glb);
+            return fsExtra.outputFile(outputPath, extractI3dm(i3dm).glb);
         });
 }
 
@@ -374,7 +371,7 @@ function readCmptWriteGlb(inputPath, outputPath, force) {
                 return checkFileOverwritable(glbPath, force);
             }).then(function() {
                 return Promise.map(glbPaths, function(glbPath, index) {
-                    return fsWriteFile(glbPath, glbs[index]);
+                    return fsExtra.outputFile(glbPath, glbs[index]);
                 });
             });
         });
@@ -387,7 +384,7 @@ function readAndOptimizeB3dm(inputPath, outputPath, force, optionArgs) {
     var b3dm;
     return checkFileOverwritable(outputPath, force)
         .then(function() {
-            return fsReadFile(inputPath);
+            return fsExtra.readFile(inputPath);
         })
         .then(function(fileBuffer) {
             gzipped = isGzipped(fileBuffer);
@@ -408,7 +405,7 @@ function readAndOptimizeB3dm(inputPath, outputPath, force, optionArgs) {
             return b3dmBuffer;
         })
         .then(function(buffer) {
-            return fsWriteFile(outputPath, buffer);
+            return fsExtra.outputFile(outputPath, buffer);
         });
 }
 
@@ -419,7 +416,7 @@ function readAndOptimizeI3dm(inputPath, outputPath, force, optionArgs) {
     var i3dm;
     return checkFileOverwritable(outputPath, force)
         .then(function() {
-            return fsReadFile(inputPath);
+            return fsExtra.readFile(inputPath);
         })
         .then(function(fileBuffer) {
             gzipped = isGzipped(fileBuffer);
@@ -440,6 +437,6 @@ function readAndOptimizeI3dm(inputPath, outputPath, force, optionArgs) {
             return i3dmBuffer;
         })
         .then(function(buffer) {
-            return fsWriteFile(outputPath, buffer);
+            return fsExtra.outputFile(outputPath, buffer);
         });
 }

--- a/tools/lib/databaseToTileset.js
+++ b/tools/lib/databaseToTileset.js
@@ -7,8 +7,6 @@ var sqlite3 = require('sqlite3');
 var zlib = require('zlib');
 var isGzipped = require('../lib/isGzipped');
 
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
-
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
@@ -63,5 +61,5 @@ function writeFile(outputDirectory, file, data) {
     if (isGzipped(data)) {
         data = zlib.gunzipSync(data);
     }
-    return fsExtraOutputFile(filePath, data);
+    return fsExtra.outputFile(filePath, data);
 }

--- a/tools/lib/directoryExists.js
+++ b/tools/lib/directoryExists.js
@@ -1,7 +1,5 @@
 'use strict';
-var Promise = require('bluebird');
 var fsExtra = require('fs-extra');
-var fsStat = Promise.promisify(fsExtra.stat);
 
 module.exports = directoryExists;
 
@@ -9,7 +7,7 @@ module.exports = directoryExists;
  * @private
  */
 function directoryExists(directory) {
-    return fsStat(directory)
+    return fsExtra.stat(directory)
         .then(function(stats) {
             return stats.isDirectory();
         })

--- a/tools/lib/fileExists.js
+++ b/tools/lib/fileExists.js
@@ -1,7 +1,5 @@
 'use strict';
-var Promise = require('bluebird');
 var fsExtra = require('fs-extra');
-var fsStat = Promise.promisify(fsExtra.stat);
 
 module.exports = fileExists;
 
@@ -9,7 +7,7 @@ module.exports = fileExists;
  * @private
  */
 function fileExists(filePath) {
-    return fsStat(filePath)
+    return fsExtra.stat(filePath)
         .then(function(stats) {
             return stats.isFile();
         })

--- a/tools/lib/getDefaultWriteCallback.js
+++ b/tools/lib/getDefaultWriteCallback.js
@@ -1,9 +1,6 @@
 'use strict';
 var fsExtra = require('fs-extra');
 var path = require('path');
-var Promise = require('bluebird');
-
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
 
 module.exports = getDefaultWriteCallback;
 
@@ -13,6 +10,6 @@ module.exports = getDefaultWriteCallback;
 function getDefaultWriteCallback(outputDirectory) {
     return function(file, data) {
         var outputFile = path.join(outputDirectory, file);
-        return fsExtraOutputFile(outputFile, data);
+        return fsExtra.outputFile(outputFile, data);
     };
 }

--- a/tools/lib/gzipTileset.js
+++ b/tools/lib/gzipTileset.js
@@ -9,8 +9,6 @@ var getDefaultWriteCallback = require('./getDefaultWriteCallback');
 var isGzippedFile = require('./isGzippedFile');
 var isTile = require('./isTile');
 
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
@@ -70,7 +68,7 @@ function gzipTileset(options) {
                                             // File is already in the correct state
                                             copyFile(inputFile, file, writeFile);
                                         } else {
-                                            fsExtraReadFile(inputFile)
+                                            fsExtra.readFile(inputFile)
                                                 .then(function(data) {
                                                     data = operation(data);
                                                     writeFile(file, data);
@@ -125,7 +123,7 @@ function getWriteFile(writeCallback, numberOfFiles, resolve, reject) {
 }
 
 function copyFile(inputFile, file, writeFile) {
-    return fsExtraReadFile(inputFile)
+    return fsExtra.readFile(inputFile)
         .then(function(data) {
             return writeFile(file, data);
         });

--- a/tools/lib/isGzippedFile.js
+++ b/tools/lib/isGzippedFile.js
@@ -1,9 +1,6 @@
 'use strict';
-var Promise = require('bluebird');
 var fsExtra = require('fs-extra');
 var isGzipped = require('./isGzipped');
-
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
 
 module.exports = isGzippedFile;
 
@@ -11,7 +8,7 @@ module.exports = isGzippedFile;
  * @private
  */
 function isGzippedFile(file) {
-    return fsExtraReadFile(file)
+    return fsExtra.readFile(file)
         .then(function (buffer) {
             return isGzipped(buffer);
         });

--- a/tools/lib/runPipeline.js
+++ b/tools/lib/runPipeline.js
@@ -10,10 +10,6 @@ var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
 
-var fsExtraCopy = Promise.promisify(fsExtra.copy);
-var fsExtraEmptyDir = Promise.promisify(fsExtra.emptyDir);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
-
 module.exports = runPipeline;
 
 /**
@@ -41,7 +37,7 @@ function runPipeline(pipeline, options) {
         path.join(path.dirname(inputDirectory), path.basename(inputDirectory) + '-processed')));
 
     if (!defined(stages)) {
-        return fsExtraCopy(inputDirectory, outputDirectory);
+        return fsExtra.copy(inputDirectory, outputDirectory);
     }
 
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -98,7 +94,7 @@ function runPipeline(pipeline, options) {
 
     // Run the stages in sequence
     return Promise.each(stageObjects, function(stage) {
-        return fsExtraEmptyDir(stage.options.outputDirectory)
+        return fsExtra.emptyDir(stage.options.outputDirectory)
             .then(function() {
                 if (defined(logCallback)) {
                     logCallback('Running ' + stage.name);
@@ -107,8 +103,8 @@ function runPipeline(pipeline, options) {
             });
     }).finally(function() {
         return Promise.all([
-            fsExtraRemove(workingDirectory1),
-            fsExtraRemove(workingDirectory2)
+            fsExtra.remove(workingDirectory1),
+            fsExtra.remove(workingDirectory2)
         ]);
     });
 }

--- a/tools/lib/tilesetToDatabase.js
+++ b/tools/lib/tilesetToDatabase.js
@@ -6,19 +6,14 @@ var path = require('path');
 var Promise = require('bluebird');
 var sqlite3 = require('sqlite3');
 var zlib = require('zlib');
-var fileExists = require('../lib/fileExists');
 var isGzipped = require('../lib/isGzipped');
 var isTile = require('../lib/isTile');
-
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
 
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
 
 module.exports = tilesetToDatabase;
-
 
 /**
  * Generates a sqlite database for a tileset, saved as a .3dtiles file.
@@ -35,64 +30,65 @@ function tilesetToDatabase(inputDirectory, outputFile) {
     outputFile = defaultValue(outputFile,
         path.join(path.dirname(inputDirectory), path.basename(inputDirectory) + '.3dtiles'));
 
-    return fileExists(outputFile)
-        .then(function(exists) {
-            if (exists) {
-                // Delete the .3dtiles file if it already exists
-                return fsExtraRemove(outputFile);
-            }
-        })
-        .then(function() {
+    var db;
+    var dbRun;
+    // Delete the .3dtiles file if it already exists
+    return Promise.resolve(fsExtra.remove(outputFile))
+        .then(function () {
             // Create the database.
-            var db = new sqlite3.Database(outputFile, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE);
-            var dbRun = Promise.promisify(db.run, {context : db});
+            db = new sqlite3.Database(outputFile, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE);
+            dbRun = Promise.promisify(db.run, {context: db});
 
             // Disable journaling and create the table.
-            return dbRun('PRAGMA journal_mode=off;')
-                .then(function() {
-                    return dbRun('BEGIN');
-                })
-                .then(function() {
-                    return dbRun('CREATE TABLE media (key TEXT PRIMARY KEY, content BLOB)');
-                })
-                .then(function() {
-                    //Build the collection of file paths to be inserted.
-                    var filePaths = [];
-                    var stream = klaw(inputDirectory);
-                    stream.on('readable', function() {
-                        var filePath = stream.read();
-                        while (defined(filePath)) {
-                            if (filePath.stats.isFile()) {
-                                filePaths.push(filePath.path);
-                            }
-                            filePath = stream.read();
-                        }
-                    });
+            return dbRun('PRAGMA journal_mode=off;');
+        })
+        .then(function () {
+            return dbRun('BEGIN');
+        })
+        .then(function () {
+            return dbRun('CREATE TABLE media (key TEXT PRIMARY KEY, content BLOB)');
+        })
+        .then(function () {
+            //Build the collection of file paths to be inserted.
+            var filePaths = [];
+            var stream = klaw(inputDirectory);
+            stream.on('readable', function () {
+                var filePath = stream.read();
+                while (defined(filePath)) {
+                    if (filePath.stats.isFile()) {
+                        filePaths.push(filePath.path);
+                    }
+                    filePath = stream.read();
+                }
+            });
 
-                    return new Promise(function(resolve, reject) {
-                        stream.on('error', reject);
-                        stream.on('end', resolve);
-                    }).thenReturn(filePaths);
-                })
-                .then(function(filePaths) {
-                    return Promise.map(filePaths, function(filePath) {
-                        return fsExtraReadFile(filePath)
-                            .then(function(data) {
-                                filePath = path.normalize(path.relative(inputDirectory, filePath)).replace(/\\/g, '/');
-                                // Only gzip tiles and json files. Other files like external textures should not be gzipped.
-                                var shouldGzip = isTile(filePath) || path.extname(filePath) === '.json';
-                                if (shouldGzip && !isGzipped(data)) {
-                                    data = zlib.gzipSync(data);
-                                }
-                                return dbRun('INSERT INTO media VALUES (?, ?)', [filePath, data]);
-                            });
-                    }, {concurrency : 100});
-                })
-                .then(function() {
-                    return dbRun('COMMIT');
-                })
-                .finally(function() {
-                    db.close();
+            return new Promise(function (resolve, reject) {
+                stream.on('error', reject);
+                stream.on('end', function () {
+                    resolve(filePaths);
                 });
+            });
+        })
+        .then(function (filePaths) {
+            return Promise.map(filePaths, function (filePath) {
+                return fsExtra.readFile(filePath)
+                    .then(function (data) {
+                        filePath = path.normalize(path.relative(inputDirectory, filePath)).replace(/\\/g, '/');
+                        // Only gzip tiles and json files. Other files like external textures should not be gzipped.
+                        var shouldGzip = isTile(filePath) || path.extname(filePath) === '.json';
+                        if (shouldGzip && !isGzipped(data)) {
+                            data = zlib.gzipSync(data);
+                        }
+                        return dbRun('INSERT INTO media VALUES (?, ?)', [filePath, data]);
+                    });
+            }, {concurrency: 100});
+        })
+        .then(function () {
+            return dbRun('COMMIT');
+        })
+        .finally(function () {
+            if (defined(db)) {
+                db.close();
+            }
         });
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -24,19 +24,19 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cesium": "^1.32",
-    "fs-extra": "^2.1.2",
+    "fs-extra": "^3.0.1",
     "gltf-pipeline": "^0.1.0-alpha12",
     "klaw": "^1.3.1",
     "sqlite3": "^3.1.8",
     "uuid": "^3.0.1",
-    "yargs": "^7.1.0"
+    "yargs": "^8.0.1"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.4",
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.3",
-    "jasmine-spec-reporter": "^3.3.0",
+    "jasmine-spec-reporter": "^4.1.0",
     "jsdoc": "^3.4.3",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",

--- a/tools/specs/lib/databaseToTilesetSpec.js
+++ b/tools/specs/lib/databaseToTilesetSpec.js
@@ -1,12 +1,8 @@
 'use strict';
 var fsExtra = require('fs-extra');
-var Promise = require('bluebird');
 var databaseToTileset = require('../../lib/databaseToTileset');
 var fileExists = require('../../lib/fileExists');
 var isGzipped = require('../../lib/isGzipped');
-
-var fsExtraReadFile = Promise.promisify(fsExtra.readJson);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
 
 var inputFile = './specs/data/tileset.3dtiles';
 var outputDirectory = './specs/data/Tileset/';
@@ -14,7 +10,7 @@ var tilesetJsonFile = './specs/data/TilesetOfTilesets/tileset.json';
 
 describe('databaseToTileset', function() {
     afterEach(function (done) {
-        fsExtraRemove(outputDirectory)
+        fsExtra.remove(outputDirectory)
             .then(function() {
                 done();
             });
@@ -26,7 +22,7 @@ describe('databaseToTileset', function() {
                 return fileExists(tilesetJsonFile)
                     .then(function(exists) {
                         expect(exists).toEqual(true);
-                        return fsExtraReadFile(tilesetJsonFile);
+                        return fsExtra.readJson(tilesetJsonFile);
                     }).then(function(data) {
                         expect(isGzipped(data)).toBe(false);
                     });

--- a/tools/specs/lib/extractCmptSpec.js
+++ b/tools/specs/lib/extractCmptSpec.js
@@ -1,9 +1,7 @@
 'use strict';
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var Promise = require('bluebird');
 var extractCmpt = require('../../lib/extractCmpt');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var compositePath = './specs/data/composite.cmpt';
 var compositeOfCompositePath = './specs/data/compositeOfComposite.cmpt';
@@ -13,11 +11,11 @@ describe('extractCmpt', function() {
     var compositeOfCompositeBuffer;
     beforeAll(function(done) {
         Promise.all([
-            fsReadFile(compositePath)
+            fsExtra.readFile(compositePath)
                 .then(function(data) {
                     compositeBuffer = data;
                 }),
-            fsReadFile(compositeOfCompositePath)
+            fsExtra.readFile(compositeOfCompositePath)
                 .then(function(data) {
                     compositeOfCompositeBuffer = data;
                 })

--- a/tools/specs/lib/gzipTilesetSpec.js
+++ b/tools/specs/lib/gzipTilesetSpec.js
@@ -5,10 +5,6 @@ var Promise = require('bluebird');
 var isGzippedFile = require('../../lib/isGzippedFile');
 var gzipTileset = require('../../lib/gzipTileset');
 
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
-
 var tilesetDirectory = './specs/data/TilesetOfTilesets/';
 var tilesetJson = './specs/data/TilesetOfTilesets/tileset.json';
 var gzippedDirectory = './specs/data/TilesetOfTilesets-gzipped';
@@ -19,8 +15,8 @@ var ungzippedJson = './specs/data/TilesetOfTilesets-ungzipped/tileset.json';
 describe('gzipTileset', function() {
     afterEach(function (done) {
         Promise.all([
-            fsExtraRemove(gzippedDirectory),
-            fsExtraRemove(ungzippedDirectory)
+            fsExtra.remove(gzippedDirectory),
+            fsExtra.remove(ungzippedDirectory)
         ]).then(function() {
             done();
         });
@@ -94,8 +90,8 @@ describe('gzipTileset', function() {
                 return gzipTileset(gzipAgainOptions)
                     .then(function() {
                         var promises = [
-                            fsExtraReadFile(gzippedJson),
-                            fsExtraReadFile(ungzippedJson)
+                            fsExtra.readFile(gzippedJson),
+                            fsExtra.readFile(ungzippedJson)
                         ];
                         return Promise.all(promises)
                             .then(function(contents) {
@@ -114,8 +110,8 @@ describe('gzipTileset', function() {
         expect(gzipTileset(ungzipOptions)
             .then(function() {
                 var promises = [
-                    fsExtraReadFile(tilesetJson),
-                    fsExtraReadFile(ungzippedJson)
+                    fsExtra.readFile(tilesetJson),
+                    fsExtra.readFile(ungzippedJson)
                 ];
                 return Promise.all(promises)
                     .then(function(contents) {
@@ -176,7 +172,7 @@ describe('gzipTileset', function() {
         var outputDirectory = gzippedDirectory;
         var writeCallback = function(file, data) {
             var outputFile = path.join(outputDirectory, file);
-            return fsExtraOutputFile(outputFile, data);
+            return fsExtra.outputFile(outputFile, data);
         };
         var gzipOptions = {
             inputDirectory : tilesetDirectory,

--- a/tools/specs/lib/optimizeGlbSpec.js
+++ b/tools/specs/lib/optimizeGlbSpec.js
@@ -1,16 +1,14 @@
 'use strict';
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var Promise = require('bluebird');
 var optimizeGlb = require('../../lib/optimizeGlb');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var glbPath = './specs/data/CesiumTexturedBox/CesiumTexturedBox.glb';
 
 describe('optimizeGlb', function() {
     var buffer;
     beforeAll(function(done) {
-        fsReadFile(glbPath)
+        fsExtra.readFile(glbPath)
             .then(function(data) {
                 buffer = data;
                 done();

--- a/tools/specs/lib/runPipelineSpec.js
+++ b/tools/specs/lib/runPipelineSpec.js
@@ -1,12 +1,8 @@
 'use strict';
 var fsExtra = require('fs-extra');
 var path = require('path');
-var Promise = require('bluebird');
 var isGzippedFile = require('../../lib/isGzippedFile');
 var runPipeline = require('../../lib/runPipeline');
-
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
 
 var inputDirectory = './specs/data/TilesetOfTilesets/';
 var outputDirectory = './specs/data/TilesetOfTilesets-processed';
@@ -14,7 +10,7 @@ var outputJson = './specs/data/TilesetOfTilesets-processed/tileset.json';
 
 describe('runPipeline', function() {
     afterEach(function(done) {
-        fsExtraRemove(outputDirectory)
+        fsExtra.remove(outputDirectory)
             .then(done);
     });
 
@@ -178,7 +174,7 @@ describe('runPipeline', function() {
     it('accepts custom writeCallback', function (done) {
         var writeCallback = function(file, data) {
             var outputFile = path.join(outputDirectory, file);
-            return fsExtraOutputFile(outputFile, data);
+            return fsExtra.outputFile(outputFile, data);
         };
 
         var pipeline = {

--- a/tools/specs/lib/tilesetToDatabseSpec.js
+++ b/tools/specs/lib/tilesetToDatabseSpec.js
@@ -8,10 +8,7 @@ var fileExists = require('../../lib/fileExists');
 var isGzipped = require('../../lib/isGzipped');
 var tilesetToDatabase = require('../../lib/tilesetToDatabase');
 
-var fsExtraReadJson = Promise.promisify(fsExtra.readJson);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
 var zlibGunzip = Promise.promisify(zlib.gunzip);
-
 var getStringFromTypedArray = Cesium.getStringFromTypedArray;
 
 var inputDirectory = './specs/data/TilesetOfTilesets/';
@@ -20,17 +17,16 @@ var outputFile = './specs/data/TilesetOfTilesets.3dtiles';
 
 describe('tilesetToDatabase', function() {
     afterEach(function (done) {
-        fsExtraRemove(outputFile)
-            .then(function() {
-                done();
-            });
+        fsExtra.remove(outputFile)
+            .then(done)
+            .catch(done.fail);
     });
 
     it('creates a sqlite database from a tileset', function(done) {
         expect(tilesetToDatabase(inputDirectory, outputFile)
             .then(function() {
                 var db;
-                return fileExists(outputFile)
+                return Promise.resolve(fileExists(outputFile))
                     .then(function(exists) {
                         expect(exists).toEqual(true);
                     }).then(function() {
@@ -45,7 +41,7 @@ describe('tilesetToDatabase', function() {
 
                         return Promise.all([
                             zlibGunzip(content),
-                            fsExtraReadJson(tilesetJsonFile)
+                            fsExtra.readJson(tilesetJsonFile)
                         ]).then(function(data) {
                             var jsonStr = getStringFromTypedArray(data[0]);
                             var dbTilesetJson = JSON.parse(jsonStr);


### PR DESCRIPTION
A few npm dependencies were major versions behind, so this updates `yargs`, `fs-extra`, and `jasmin-spec-reporter` to their latest versions.

The major change here is `fs-extra`, which now has promise implementations of all functions by default, this means there's no reason to manually `Promisify` a function any more, the result is less code overall.

There is one important edge case, `fs-extra` uses built-in native Node promises, which do not have a `finally` function. If you start a promise change with an `fs-extra` function, you need to wrap it in `Promise.resolve` in order to make use of finally at the end (assuming you are using finally at all, if not you don't need to worry about it. The upside is that your code will always error if you forget to do this.