### PR TITLE
Fix translucent/opaque tileset techniques

### DIFF
--- a/generator/lib/createGltf.js
+++ b/generator/lib/createGltf.js
@@ -182,6 +182,8 @@ function createGltf(options) {
             extensions : {
                 KHR_materials_common : {
                     technique : technique,
+                    transparent : transparent,
+                    doubleSided : doubleSided,
                     values : {
                         ambient : ambient,
                         diffuse : diffuse,


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/pull/5308#discussion_r117840434

I had to do a similar thing in `obj2gltf` due to the inconsistencies of the `KHR_materials_common` extension.