### PR TITLE
Use nyc for coverage

### DIFF
--- a/samples-generator/.gitignore
+++ b/samples-generator/.gitignore
@@ -7,7 +7,9 @@ npm-debug.log
 .idea/tasks.xml
 
 # Generated files
+.nyc_output
 .eslintcache
+coverage
 output
 *.tgz
 *.zip

--- a/samples-generator/.npmignore
+++ b/samples-generator/.npmignore
@@ -1,3 +1,4 @@
+/coverage
 /output
 /.idea
 .eslintrc.json
@@ -6,3 +7,4 @@ gulpfile.js
 *.tgz
 *.zip
 .eslintcache
+.nyc_output

--- a/samples-generator/gulpfile.js
+++ b/samples-generator/gulpfile.js
@@ -7,6 +7,8 @@ var Jasmine = require('jasmine');
 var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 var path = require('path');
 var yargs = require('yargs');
+var fsExtra = require('fs-extra');
+var open = require('open');
 
 var defined = Cesium.defined;
 var argv = yargs.argv;
@@ -43,4 +45,21 @@ gulp.task('test-watch', function () {
             console.log('Tests failed to execute.');
         }
     });
+});
+
+gulp.task('coverage', function () {
+    fsExtra.removeSync('coverage');
+    child_process.execSync('nyc' +
+        ' --all' +
+        ' --reporter=lcov' +
+        ' --dir coverage' +
+        ' -x "specs/**"' +
+        ' -x "coverage/**"' +
+        ' -x "gulpfile.js"' +
+        ' -x "index.js"' +
+        ' node_modules/jasmine/bin/jasmine.js' +
+        ' JASMINE_CONFIG_PATH=specs/jasmine.json', {
+        stdio: [process.stdin, process.stdout, process.stderr]
+    });
+    open('coverage/lcov-report/index.html');
 });

--- a/samples-generator/package.json
+++ b/samples-generator/package.json
@@ -33,16 +33,20 @@
   "devDependencies": {
     "eslint": "^4.1.1",
     "eslint-config-cesium": "^2.0.0",
+    "fs-extra": "^3.0.1",
     "gulp": "^3.9.1",
     "jasmine": "^2.6.0",
     "jasmine-spec-reporter": "^4.1.0",
+    "nyc": "^11.0.3",
+    "open": "^0.0.5",
     "requirejs": "^2.3.3",
     "yargs": "^8.0.1"
   },
   "scripts": {
     "eslint": "eslint \"./**/*.js\" --cache --quiet",
     "test": "gulp test",
-    "test-watch": "gulp test-watch"
+    "test-watch": "gulp test-watch",
+    "coverage": "gulp coverage"
   },
   "bin": {
     "3d-tiles-samples-generator": "./bin/3d-tiles-samples-generator"

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log
 .idea/tasks.xml
 
 # Generated files
+.nyc_output
 .eslintcache
 doc
 coverage

--- a/tools/.npmignore
+++ b/tools/.npmignore
@@ -11,3 +11,4 @@
 gulpfile.js
 *.tgz
 .eslintcache
+.nyc_output

--- a/tools/gulpfile.js
+++ b/tools/gulpfile.js
@@ -50,9 +50,9 @@ gulp.task('test-watch', function () {
 
 gulp.task('coverage', function () {
     fsExtra.removeSync('coverage/server');
-    child_process.execSync('istanbul' +
-        ' cover' +
-        ' --include-all-sources' +
+    child_process.execSync('nyc' +
+        ' --all' +
+        ' --reporter=lcov' +
         ' --dir coverage' +
         ' -x "doc/**"' +
         ' -x "specs/**"' +

--- a/tools/package.json
+++ b/tools/package.json
@@ -35,10 +35,10 @@
     "eslint": "^4.1.1",
     "eslint-config-cesium": "^2.0.0",
     "gulp": "^3.9.1",
-    "istanbul": "^0.4.5",
     "jasmine": "^2.5.3",
     "jasmine-spec-reporter": "^4.1.0",
     "jsdoc": "^3.4.3",
+    "nyc": "^11.0.3",
     "open": "^0.0.5",
     "request": "^2.81.0",
     "requirejs": "^2.3.3"

--- a/validator/.gitignore
+++ b/validator/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log
 .idea/tasks.xml
 
 # Generated files
+.nyc_output
 .eslintcache
 doc
 coverage

--- a/validator/.npmignore
+++ b/validator/.npmignore
@@ -10,3 +10,4 @@
 gulpfile.js
 *.tgz
 .eslintcache
+.nyc_output

--- a/validator/gulpfile.js
+++ b/validator/gulpfile.js
@@ -51,11 +51,16 @@ gulp.task('test-watch', function () {
 
 gulp.task('coverage', function () {
     fsExtra.removeSync('coverage/server');
-    child_process.execSync('istanbul' +
-        ' cover' +
-        ' --include-all-sources' +
+    child_process.execSync('nyc' +
+        ' --all' +
+        ' --reporter=lcov' +
         ' --dir coverage' +
-        ' -x "bin/** doc/** specs/** coverage/** index.js gulpfile.js"' +
+        ' -x "bin/**"' +
+        ' -x "doc/**"' +
+        ' -x "specs/**"' +
+        ' -x "coverage/**"' +
+        ' -x index.js' +
+        ' -x gulpfile.js"' +
         ' node_modules/jasmine/bin/jasmine.js' +
         ' JASMINE_CONFIG_PATH=specs/jasmine.json', {
         stdio: [process.stdin, process.stdout, process.stderr]

--- a/validator/package.json
+++ b/validator/package.json
@@ -31,10 +31,10 @@
     "eslint": "^4.1.1",
     "eslint-config-cesium": "^2.0.0",
     "gulp": "3.9.1",
-    "istanbul": "0.4.4",
     "jasmine": "2.4.1",
     "jasmine-spec-reporter": "2.5.0",
     "jsdoc": "3.4.0",
+    "nyc": "^11.0.3",
     "open": "0.0.5",
     "request": "2.74.0",
     "requirejs": "2.2.0"


### PR DESCRIPTION
Add [nyc](https://github.com/istanbuljs/nyc). to each of the three repositories for code coverage.

`nyc` is the new version of `istanbul`. (They retained the istanbul name for he actual coverage library, but nyc is now the command line tool to run it).  This happened a while ago and we've been on an old version of istanbul until now.

The `tools` tests don't run on my computer, but the other two repositories work and show the coverage successfully.