### PR TITLE
Validate Tileset checks for refine property

### DIFF
--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -28,7 +28,7 @@ function validateTileset(tileset, tilesetDirectory) {
         return Promise.resolve(message);
     }
 
-    return validateTileHierarchy(tileset.root, tilesetDirectory);
+    return Promise.resolve(validateTileHierarchy(tileset.root, tilesetDirectory));
 }
 
 function validateTopLevel(tileset) {
@@ -36,8 +36,8 @@ function validateTopLevel(tileset) {
         return 'Tileset must declare its geometricError as a top-level property.';
     }
 
-    if (defined(tileset.root.refine)){
-        if (tileset.root.refine !== 'ADD' && tileset.root.refine !== 'REPLACE'){
+    if (defined(tileset.root.refine)) {
+        if (tileset.root.refine !== 'ADD' && tileset.root.refine !== 'REPLACE') {
             return 'Refine property in root tileset must have either ADD or REPLACE as its value';
         }
     }
@@ -79,6 +79,12 @@ function validateTileHierarchy(root, tilesetDirectory) {
 
             if (defined(contentSphere) && defined(tileSphere) && !sphereInsideSphere(contentSphere, tileSphere)) {
                 return 'content sphere [' + contentSphere + '] is not within tile sphere + [' + tileSphere + ']';
+            }
+        }
+
+        if(defined(tile.refine)) {
+            if (tile.refine !== 'ADD' && tile.refine !== 'REPLACE') {
+                return 'Refine property in tileset must have either ADD or REPLACE as its value.';
             }
         }
 

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -36,8 +36,8 @@ function validateTopLevel(tileset) {
         return 'Tileset must declare its geometricError as a top-level property.';
     }
 
-    if(defined(tileset.root.refine)){
-        if(tileset.root.refine !== 'ADD' && tileset.root.refine !== 'REPLACE'){
+    if (defined(tileset.root.refine)){
+        if (tileset.root.refine !== 'ADD' && tileset.root.refine !== 'REPLACE'){
             return 'Refine property in root tileset must have either ADD or REPLACE as its value';
         }
     }

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -36,11 +36,9 @@ function validateTopLevel(tileset) {
         return 'Tileset must declare its geometricError as a top-level property.';
     }
 
-    if (defined(tileset.root.refine)) {
-        if (tileset.root.refine !== 'ADD' && tileset.root.refine !== 'REPLACE') {
-            return 'Refine property in root tileset must have either ADD or REPLACE as its value';
-        }
-    }  
+    if (!defined(tileset.root.refine)) {
+        return 'Tileset must define refine property in root tile';
+    }
 
     if (!defined(tileset.asset)) {
         return 'Tileset must declare its asset as a top-level property.';
@@ -108,9 +106,9 @@ function validateTileHierarchy(root, tilesetDirectory) {
             }
         }
 
-        if(defined(tile.refine)) {
+        if (defined(tile.refine)) {
             if (tile.refine !== 'ADD' && tile.refine !== 'REPLACE') {
-                return 'Refine property in tileset must have either ADD or REPLACE as its value.';
+                return 'Refine property in tile must have either "ADD" or "REPLACE" as its value.';
             }
         }
 

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -35,6 +35,12 @@ function validateTopLevel(tileset) {
     if (!defined(tileset.geometricError)) {
         return 'Tileset must declare its geometricError as a top-level property.';
     }
+
+    if(defined(tileset.root.refine)){
+        if(tileset.root.refine !== 'ADD' && tileset.root.refine !== 'REPLACE'){
+            return 'Refine property in root tileset must have either ADD or REPLACE as its value';
+        }
+    }
 }
 
 function validateTileHierarchy(root, tilesetDirectory) {

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -56,4 +56,13 @@ describe('validateTileset', function() {
                 expect(message).toBe('Tileset must declare its geometricError as a top-level property.');
             }), done).toResolve();
     });
+
+    it('returns error message when refine property of root tile has incorrect value', function(done) {
+        var tileset = clone(sampleTileset, true);
+        tileset.root.refine = 'NEW';
+        expect(validateTileset(tileset)
+            .then(function(message) {
+                expect(message).toBe('Refine property in root tileset must have either ADD or REPLACE as its value');
+            }), done).toResolve();
+    });
 });

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -68,13 +68,13 @@ describe('validateTileset', function() {
             }), done).toResolve();
     });
   
-    it('returns error message when refine property of tileset has incorrect value', function(done) {
+    it('returns error message when refine property of tile has incorrect value', function(done) {
         var tileset = clone(sampleTileset, true);
         tileset.root.children[0].refine = 'NEW';
         expect(validateTileset(tileset)
             .then(function(message) {
-                expect(message).toBe('Refine property in tileset must have either ADD or REPLACE as its value.');
-          }), done).toResolve();
+                expect(message).toBe('Refine property in tile must have either "ADD" or "REPLACE" as its value.');
+            }), done).toResolve();
     });
   
     it('returns error message when the top-level geometricError is missing', function(done) {
@@ -86,12 +86,12 @@ describe('validateTileset', function() {
             }), done).toResolve();
     });
 
-    it('returns error message when refine property of root tile has incorrect value', function(done) {
+    it('returns error message when refine property is not defined in root tile', function(done) {
         var tileset = clone(sampleTileset, true);
-        tileset.root.refine = 'NEW';
+        delete tileset.root.refine;
         expect(validateTileset(tileset)
             .then(function(message) {
-                expect(message).toBe('Refine property in root tileset must have either ADD or REPLACE as its value');
+                expect(message).toBe('Tileset must define refine property in root tile');
             }), done).toResolve();
     });
           

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -26,7 +26,7 @@ var sampleTileset = {
                         boundingVolume: {
                             region: [-1.3197209591796106, 0.6988424218, -1.31968, 0.698874, 0, 10]
                         },
-                        geometricError: 0,
+                        geometricError: 0
                     }
                 ]
             },

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -6,7 +6,7 @@ var clone = Cesium.clone;
 
 var sampleTileset = {
     asset: {
-        version: '0.0'
+        version: '1.0'
     },
     geometricError: 240,
     root: {
@@ -26,7 +26,7 @@ var sampleTileset = {
                         boundingVolume: {
                             region: [-1.3197209591796106, 0.6988424218, -1.31968, 0.698874, 0, 10]
                         },
-                        geometricError: 0
+                        geometricError: 0,
                     }
                 ]
             },
@@ -41,10 +41,12 @@ var sampleTileset = {
 };
 
 describe('validateTileset', function() {
-    it('succeeds for valid tileset', function(done) {
-        expect(validateTileset(sampleTileset)
+    it('returns error message when refine property of tileset has incorrect value', function(done) {
+        var tileset = clone(sampleTileset, true);
+        tileset.root.children[0].refine = 'NEW';
+        expect(validateTileset(tileset)
             .then(function(message) {
-                expect(message).toBeUndefined();
+                expect(message).toBe('Refine property in tileset must have either ADD or REPLACE as its value.');
             }), done).toResolve();
     });
 
@@ -63,6 +65,13 @@ describe('validateTileset', function() {
         expect(validateTileset(tileset)
             .then(function(message) {
                 expect(message).toBe('Refine property in root tileset must have either ADD or REPLACE as its value');
+            }), done).toResolve();
+    });
+
+    it('succeeds for valid tileset', function(done) {
+        expect(validateTileset(sampleTileset)
+            .then(function(message) {
+                expect(message).toBeUndefined();
             }), done).toResolve();
     });
 });


### PR DESCRIPTION
@lilleyse 
Issue #95: Validate Tileset checks for refine property and its value in root tiles, if refine is defined.