### PR TITLE
Check for box type content bounding volume inside tile with box type bounding volume

### DIFF
--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -96,10 +96,9 @@ function boxInsideBox(boxInner, boxOuter) {
     cube[6] = new Cartesian3(1, 1, 1);
     cube[7] = new Cartesian3(1, 1, -1);
 
-    var i = 0;
     var transformInnerInverse = Matrix4.inverse(transformOuter, transformOuter);
     var EPSILON8 = CesiumMath.EPSILON8;
-    for (i = 0; i < 8; i++) {
+    for (var i = 0; i < 8; i++) {
         cube[i] = Matrix4.multiplyByPoint(transformInner, cube[i], cube[i]);
         cube[i] = Matrix4.multiplyByPoint(transformInnerInverse, cube[i], cube[i]);
         var min = Cartesian3.minimumComponent(cube[i]);

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -2,6 +2,7 @@
 var Cesium = require('cesium');
 
 var Cartesian3 = Cesium.Cartesian3;
+var CesiumMath = Cesium.Math;
 var Matrix3 = Cesium.Matrix3;
 var Matrix4 = Cesium.Matrix4;
 
@@ -105,8 +106,14 @@ function boxInsideBox(boxInner, boxOuter) {
         cube[i] = Matrix4.multiplyByPoint(transformInnerInverse,cube[i],cube[i]);
     }
 
+    var EPSILON8 = CesiumMath.EPSILON8;
     for (i = 0; i < 8; i++) {
-        if (cube[i].x < 0 || cube[i].x > 1 || cube[i].y < 0 || cube[i].y > 1 || cube[i].z < 0 || cube[i].z > 1) {
+        if (cube[i].x < 0 - EPSILON8 ||
+            cube[i].x > 1 + EPSILON8 ||
+            cube[i].y < 0 - EPSILON8 ||
+            cube[i].y > 1 + EPSILON8 ||
+            cube[i].z < 0 - EPSILON8 ||
+            cube[i].z > 1 + EPSILON8) {
             return false;
         }
     }

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -77,17 +77,14 @@ var scratchInnerHalfAxes = new Matrix3();
 var scratchOuterHalfAxes = new Matrix3();
 
 function boxInsideBox(boxInner, boxOuter) {
-    // Compute inner box..
     var centerInner = Cartesian3.fromElements(boxInner[0], boxInner[1], boxInner[2], scratchInnerCenter);
     var halfAxesInner = Matrix3.fromArray(boxInner, 3, scratchInnerHalfAxes);
     var transformInner = Matrix4.fromRotationTranslation(halfAxesInner,centerInner);
 
-    // Compute outer box..
     var centerOuter = Cartesian3.fromElements(boxOuter[0], boxOuter[1], boxOuter[2], scratchOuterCenter);
     var halfAxesOuter = Matrix3.fromArray(boxOuter, 3, scratchOuterHalfAxes);
     var transformOuter = Matrix4.fromRotationTranslation(halfAxesOuter,centerOuter);
 
-    // Create a unit cube 0,0,0 to 1,1,1..
     var cube = new Array(8);
     cube[0] = new Cartesian3(0, 0, 0);
     cube[1] = new Cartesian3(0, 0, 1);
@@ -98,19 +95,16 @@ function boxInsideBox(boxInner, boxOuter) {
     cube[6] = new Cartesian3(1, 1, 1);
     cube[7] = new Cartesian3(1, 1, 0);
 
-    // TRANSFORM BY transformInner - TO GET THE INNER BOUNDING BOX IN WORLD SPACE
     var i = 0;
     for (i = 0; i < 8; i++) {
         cube[i] = Matrix4.multiplyByPoint(transformInner,cube[i],cube[i]);
     }
 
-    // TRANSFORM BY INVERSE OF transformOuter - TO GET THE BOX IN THE OUTER BOX'S SPACE
     var transformInnerInverse = Matrix4.inverse(transformOuter,transformOuter);
     for (i = 0; i < 8; i++) {
         cube[i] = Matrix4.multiplyByPoint(transformInnerInverse,cube[i],cube[i]);
     }
 
-    // COMPARE THE RESULTING CUBE WITH UNIT CUBE..
     for (i = 0; i < 8; i++) {
         if (cube[i].x < 0 || cube[i].x > 1 || cube[i].y < 0 || cube[i].y > 1 || cube[i].z < 0 || cube[i].z > 1) {
             return false;

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -61,41 +61,58 @@ function regionInsideRegion(regionInner, regionOuter) {
         (regionInner[5] <= regionOuter[5]);
 }
 
-var scratchInnnerCenter = new Cartesian3();
+var scratchInnerCenter = new Cartesian3();
 var scratchOuterCenter = new Cartesian3();
 
 function sphereInsideSphere(sphereInner, sphereOuter) {
     var radiusInner= sphereInner[3];
     var radiusOuter = sphereOuter[3];
-    var centerInner = Cartesian3.unpack(sphereInner, 0, scratchInnnerCenter);
+    var centerInner = Cartesian3.unpack(sphereInner, 0, scratchInnerCenter);
     var centerOuter = Cartesian3.unpack(sphereOuter, 0, scratchOuterCenter);
     var distance = Cartesian3.distance(centerInner, centerOuter);
     return distance <= (radiusOuter - radiusInner);
 }
-
-var scratchInnerHalfAxes = new Matrix3();
-var scratchOuterHalfAxes = new Matrix3();
-var transform = new Matrix4();
-var scratchMatrixInner = new Matrix3();
 
 // An array of 12 numbers that define an oriented bounding box.  
 // The first three elements define the x, y, and z values for the center of the box.  
 // The next three elements (with indices 3, 4, and 5) define the x axis direction and half-length.  
 // The next three elements (indices 6, 7, and 8) define the y axis direction and half-length.  
 // The last three elements (indices 9, 10, and 11) define the z axis direction and half-length.
-function boxInsideBox(boxInner, boxOuter, transform) {
-    var centerInner = Cartesian3.fromElements(boxInner[0], boxInner[1], boxInner[2], scratchInnnerCenter);
-    var halfAxesInner = Matrix3.fromArray(boxInner, 3, scratchInnerHalfAxes);
-    centerInner = Matrix4.multiplyByPoint(transform, center, center);
-    var rotationScaleInner = Matrix4.getRotation(transform, scratchMatrixInner);
-    halfAxesInner = Matrix3.multiply(rotationScaleInner, halfAxesInner, halfAxesInner);
+function boxInsideBox(boxInner, boxOuter) {
+    var centerInner = Cartesian3.fromElements(boxInner[0], boxInner[1], boxInner[2]);
+    var halfAxesInnerX = Cartesian3.fromElements(boxInner[3], boxInner[4], boxInner[5]);
+    var halfAxesInnerY = Cartesian3.fromElements(boxInner[6], boxInner[7], boxInner[8]);
+    var halfAxesInnerZ = Cartesian3.fromElements(boxInner[9], boxInner[10], boxInner[11]);
 
-    return (boxInner[0] >= boxOuter[0]) &&
-        (boxInner[1] >= boxOuter[1]) &&
-        (boxInner[2] <= boxOuter[2]) &&
-        (boxInner[3] <= boxOuter[3]) &&
-        (boxInner[4] >= boxOuter[4]) &&
-        (boxInner[5] >= boxOuter[5]) &&
-        (boxInner[6] <= boxOuter[6]) &&
-        (boxInner[7] <= boxOuter[7]);
+    var centerInnerPositive = new Cartesian3();
+    Cartesian3.add(centerInner, halfAxesInnerX, centerInnerPositive);
+    Cartesian3.add(centerInnerPositive, halfAxesInnerY, centerInnerPositive);
+    Cartesian3.add(centerInnerPositive, halfAxesInnerZ, centerInnerPositive);
+
+    var centerInnerNegative = new Cartesian3();
+    Cartesian3.subtract(centerInner, halfAxesInnerX, centerInnerNegative);
+    Cartesian3.subtract(centerInnerNegative, halfAxesInnerY, centerInnerNegative);
+    Cartesian3.subtract(centerInnerNegative, halfAxesInnerZ, centerInnerNegative);
+
+    var centerOuter = Cartesian3.fromElements(boxOuter[0], boxOuter[1], boxOuter[2]);
+    var halfAxesOuterX = Cartesian3.fromElements(boxOuter[3], boxOuter[4], boxOuter[5]);
+    var halfAxesOuterY = Cartesian3.fromElements(boxOuter[6], boxOuter[7], boxOuter[8]);
+    var halfAxesOuterZ = Cartesian3.fromElements(boxOuter[9], boxOuter[10], boxOuter[11]);
+
+    var centerOuterPositive = new Cartesian3();
+    Cartesian3.add(centerOuter, halfAxesOuterX, centerOuterPositive);
+    Cartesian3.add(centerOuterPositive, halfAxesOuterY, centerOuterPositive);
+    Cartesian3.add(centerOuterPositive, halfAxesOuterZ, centerOuterPositive);
+
+    var centerOuterNegative = new Cartesian3();
+    Cartesian3.subtract(centerOuter, halfAxesOuterX, centerOuterNegative);
+    Cartesian3.subtract(centerOuterNegative, halfAxesOuterY, centerOuterNegative);
+    Cartesian3.subtract(centerOuterNegative, halfAxesOuterZ, centerOuterNegative);
+
+    return (centerInnerPositive.x <= centerOuterPositive.x) &&
+        (centerInnerPositive.y <= centerOuterPositive.y) &&
+        (centerInnerPositive.z <= centerOuterPositive.z) &&
+        (centerInnerNegative.x >= centerOuterNegative.x) &&
+        (centerInnerNegative.y >= centerOuterNegative.y) &&
+        (centerInnerNegative.z >= centerOuterNegative.z);
 }

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -97,15 +97,13 @@ function boxInsideBox(boxInner, boxOuter) {
     cube[7] = new Cartesian3(1, 1, -1);
 
     var i = 0;
-    var transformInnerInverse;
-    var min, max;
+    var transformInnerInverse = Matrix4.inverse(transformOuter, transformOuter);
     var EPSILON8 = CesiumMath.EPSILON8;
     for (i = 0; i < 8; i++) {
         cube[i] = Matrix4.multiplyByPoint(transformInner, cube[i], cube[i]);
-        transformInnerInverse = Matrix4.inverse(transformOuter, transformOuter);
         cube[i] = Matrix4.multiplyByPoint(transformInnerInverse, cube[i], cube[i]);
-        min = Cartesian3.minimumComponent(cube[i]);
-        max = Cartesian3.maximumComponent(cube[i]);
+        var min = Cartesian3.minimumComponent(cube[i]);
+        var max = Cartesian3.maximumComponent(cube[i]);
         if (min < -1 - EPSILON8 || max > 1 + EPSILON8) {
             return false;
         }

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -73,41 +73,24 @@ function sphereInsideSphere(sphereInner, sphereOuter) {
     return distance <= (radiusOuter - radiusInner);
 }
 
-// An array of 12 numbers that define an oriented bounding box.  
-// The first three elements define the x, y, and z values for the center of the box.  
-// The next three elements (with indices 3, 4, and 5) define the x axis direction and half-length.  
-// The next three elements (indices 6, 7, and 8) define the y axis direction and half-length.  
-// The last three elements (indices 9, 10, and 11) define the z axis direction and half-length.
 function boxInsideBox(boxInner, boxOuter) {
     var centerInner = Cartesian3.fromElements(boxInner[0], boxInner[1], boxInner[2]);
-    var halfAxesInnerX = Cartesian3.fromElements(boxInner[3], boxInner[4], boxInner[5]);
-    var halfAxesInnerY = Cartesian3.fromElements(boxInner[6], boxInner[7], boxInner[8]);
-    var halfAxesInnerZ = Cartesian3.fromElements(boxInner[9], boxInner[10], boxInner[11]);
-
+    var halfDiagonalInner = Cartesian3.fromElements(boxInner[3] + boxInner[6] + boxInner[9],
+                                                    boxInner[4] + boxInner[7] + boxInner[10],
+                                                    boxInner[5] + boxInner[8] + boxInner[11]);
     var centerInnerPositive = new Cartesian3();
-    Cartesian3.add(centerInner, halfAxesInnerX, centerInnerPositive);
-    Cartesian3.add(centerInnerPositive, halfAxesInnerY, centerInnerPositive);
-    Cartesian3.add(centerInnerPositive, halfAxesInnerZ, centerInnerPositive);
-
+    Cartesian3.add(centerInner, halfDiagonalInner, centerInnerPositive);
     var centerInnerNegative = new Cartesian3();
-    Cartesian3.subtract(centerInner, halfAxesInnerX, centerInnerNegative);
-    Cartesian3.subtract(centerInnerNegative, halfAxesInnerY, centerInnerNegative);
-    Cartesian3.subtract(centerInnerNegative, halfAxesInnerZ, centerInnerNegative);
+    Cartesian3.subtract(centerInner, halfDiagonalInner, centerInnerNegative);
 
     var centerOuter = Cartesian3.fromElements(boxOuter[0], boxOuter[1], boxOuter[2]);
-    var halfAxesOuterX = Cartesian3.fromElements(boxOuter[3], boxOuter[4], boxOuter[5]);
-    var halfAxesOuterY = Cartesian3.fromElements(boxOuter[6], boxOuter[7], boxOuter[8]);
-    var halfAxesOuterZ = Cartesian3.fromElements(boxOuter[9], boxOuter[10], boxOuter[11]);
-
+    var halfDiagonalOuter = Cartesian3.fromElements(boxOuter[3] + boxOuter[6] + boxOuter[9],
+                                                    boxOuter[4] + boxOuter[7] + boxOuter[10],
+                                                    boxOuter[5] + boxOuter[8] + boxOuter[11]);
     var centerOuterPositive = new Cartesian3();
-    Cartesian3.add(centerOuter, halfAxesOuterX, centerOuterPositive);
-    Cartesian3.add(centerOuterPositive, halfAxesOuterY, centerOuterPositive);
-    Cartesian3.add(centerOuterPositive, halfAxesOuterZ, centerOuterPositive);
-
+    Cartesian3.add(centerOuter, halfDiagonalOuter, centerOuterPositive);
     var centerOuterNegative = new Cartesian3();
-    Cartesian3.subtract(centerOuter, halfAxesOuterX, centerOuterNegative);
-    Cartesian3.subtract(centerOuterNegative, halfAxesOuterY, centerOuterNegative);
-    Cartesian3.subtract(centerOuterNegative, halfAxesOuterZ, centerOuterNegative);
+    Cartesian3.subtract(centerOuter, halfDiagonalOuter, centerOuterNegative);
 
     return (centerInnerPositive.x <= centerOuterPositive.x) &&
         (centerInnerPositive.y <= centerOuterPositive.y) &&

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -12,7 +12,7 @@ module.exports = {
     isBufferValidUtf8 : isBufferValidUtf8,
     regionInsideRegion : regionInsideRegion,
     sphereInsideSphere : sphereInsideSphere,
-    boxInsideBox : boxInsideBox
+    boxInsideBox : boxInsideBox,
     boxInsideSphere : boxInsideSphere
 };
 
@@ -132,7 +132,7 @@ function boxInsideSphere(box, sphere) {
     cube[5] = new Cartesian3(-1, 1, 1);
     cube[6] = new Cartesian3(1, 1, 1);
     cube[7] = new Cartesian3(1, 1, -1);
-  
+
     for (var i = 0; i < 8; i++) {
         cube[i] = Matrix4.multiplyByPoint(transformBox, cube[i], cube[i]);
         var distance = Cartesian3.distance(cube[i], centerSphere);

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -80,39 +80,39 @@ var scratchOuterHalfAxes = new Matrix3();
 function boxInsideBox(boxInner, boxOuter) {
     var centerInner = Cartesian3.fromElements(boxInner[0], boxInner[1], boxInner[2], scratchInnerCenter);
     var halfAxesInner = Matrix3.fromArray(boxInner, 3, scratchInnerHalfAxes);
-    var transformInner = Matrix4.fromRotationTranslation(halfAxesInner,centerInner);
+    var transformInner = Matrix4.fromRotationTranslation(halfAxesInner, centerInner);
 
     var centerOuter = Cartesian3.fromElements(boxOuter[0], boxOuter[1], boxOuter[2], scratchOuterCenter);
     var halfAxesOuter = Matrix3.fromArray(boxOuter, 3, scratchOuterHalfAxes);
-    var transformOuter = Matrix4.fromRotationTranslation(halfAxesOuter,centerOuter);
+    var transformOuter = Matrix4.fromRotationTranslation(halfAxesOuter, centerOuter);
 
     var cube = new Array(8);
-    cube[0] = new Cartesian3(0, 0, 0);
-    cube[1] = new Cartesian3(0, 0, 1);
-    cube[2] = new Cartesian3(1, 0, 1);
-    cube[3] = new Cartesian3(1, 0, 0);
-    cube[4] = new Cartesian3(0, 1, 0);
-    cube[5] = new Cartesian3(0, 1, 1);
+    cube[0] = new Cartesian3(-1, -1, -1);
+    cube[1] = new Cartesian3(-1, -1, 1);
+    cube[2] = new Cartesian3(1, -1, 1);
+    cube[3] = new Cartesian3(1, -1, -1);
+    cube[4] = new Cartesian3(-1, 1, -1);
+    cube[5] = new Cartesian3(-1, 1, 1);
     cube[6] = new Cartesian3(1, 1, 1);
-    cube[7] = new Cartesian3(1, 1, 0);
+    cube[7] = new Cartesian3(1, 1, -1);
 
     var i = 0;
     for (i = 0; i < 8; i++) {
-        cube[i] = Matrix4.multiplyByPoint(transformInner,cube[i],cube[i]);
+        cube[i] = Matrix4.multiplyByPoint(transformInner, cube[i], cube[i]);
     }
 
-    var transformInnerInverse = Matrix4.inverse(transformOuter,transformOuter);
+    var transformInnerInverse = Matrix4.inverse(transformOuter, transformOuter);
     for (i = 0; i < 8; i++) {
-        cube[i] = Matrix4.multiplyByPoint(transformInnerInverse,cube[i],cube[i]);
+        cube[i] = Matrix4.multiplyByPoint(transformInnerInverse, cube[i], cube[i]);
     }
 
     var EPSILON8 = CesiumMath.EPSILON8;
     for (i = 0; i < 8; i++) {
-        if (cube[i].x < 0 - EPSILON8 ||
+        if (cube[i].x < -1 - EPSILON8 ||
             cube[i].x > 1 + EPSILON8 ||
-            cube[i].y < 0 - EPSILON8 ||
+            cube[i].y < -1 - EPSILON8 ||
             cube[i].y > 1 + EPSILON8 ||
-            cube[i].z < 0 - EPSILON8 ||
+            cube[i].z < -1 - EPSILON8 ||
             cube[i].z > 1 + EPSILON8) {
             return false;
         }

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -97,23 +97,16 @@ function boxInsideBox(boxInner, boxOuter) {
     cube[7] = new Cartesian3(1, 1, -1);
 
     var i = 0;
-    for (i = 0; i < 8; i++) {
-        cube[i] = Matrix4.multiplyByPoint(transformInner, cube[i], cube[i]);
-    }
-
-    var transformInnerInverse = Matrix4.inverse(transformOuter, transformOuter);
-    for (i = 0; i < 8; i++) {
-        cube[i] = Matrix4.multiplyByPoint(transformInnerInverse, cube[i], cube[i]);
-    }
-
+    var transformInnerInverse;
+    var min, max;
     var EPSILON8 = CesiumMath.EPSILON8;
     for (i = 0; i < 8; i++) {
-        if (cube[i].x < -1 - EPSILON8 ||
-            cube[i].x > 1 + EPSILON8 ||
-            cube[i].y < -1 - EPSILON8 ||
-            cube[i].y > 1 + EPSILON8 ||
-            cube[i].z < -1 - EPSILON8 ||
-            cube[i].z > 1 + EPSILON8) {
+        cube[i] = Matrix4.multiplyByPoint(transformInner, cube[i], cube[i]);
+        transformInnerInverse = Matrix4.inverse(transformOuter, transformOuter);
+        cube[i] = Matrix4.multiplyByPoint(transformInnerInverse, cube[i], cube[i]);
+        min = Cartesian3.minimumComponent(cube[i]);
+        max = Cartesian3.maximumComponent(cube[i]);
+        if (min < -1 - EPSILON8 || max > 1 + EPSILON8) {
             return false;
         }
     }

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -2,8 +2,6 @@
 var Cesium = require('cesium');
 
 var Cartesian3 = Cesium.Cartesian3;
-var Matrix3 = Cesium.Matrix3;
-var Matrix4 = Cesium.Matrix4;
 
 module.exports = {
     typeToComponentsLength : typeToComponentsLength,

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -2,13 +2,16 @@
 var Cesium = require('cesium');
 
 var Cartesian3 = Cesium.Cartesian3;
+var Matrix3 = Cesium.Matrix3;
+var Matrix4 = Cesium.Matrix4;
 
 module.exports = {
     typeToComponentsLength : typeToComponentsLength,
     componentTypeToByteLength : componentTypeToByteLength,
     isBufferValidUtf8 : isBufferValidUtf8,
     regionInsideRegion : regionInsideRegion,
-    sphereInsideSphere : sphereInsideSphere
+    sphereInsideSphere : sphereInsideSphere,
+    boxInsideBox : boxInsideBox
 };
 
 function typeToComponentsLength(type) {
@@ -68,4 +71,31 @@ function sphereInsideSphere(sphereInner, sphereOuter) {
     var centerOuter = Cartesian3.unpack(sphereOuter, 0, scratchOuterCenter);
     var distance = Cartesian3.distance(centerInner, centerOuter);
     return distance <= (radiusOuter - radiusInner);
+}
+
+var scratchInnerHalfAxes = new Matrix3();
+var scratchOuterHalfAxes = new Matrix3();
+var transform = new Matrix4();
+var scratchMatrixInner = new Matrix3();
+
+// An array of 12 numbers that define an oriented bounding box.  
+// The first three elements define the x, y, and z values for the center of the box.  
+// The next three elements (with indices 3, 4, and 5) define the x axis direction and half-length.  
+// The next three elements (indices 6, 7, and 8) define the y axis direction and half-length.  
+// The last three elements (indices 9, 10, and 11) define the z axis direction and half-length.
+function boxInsideBox(boxInner, boxOuter, transform) {
+    var centerInner = Cartesian3.fromElements(boxInner[0], boxInner[1], boxInner[2], scratchInnnerCenter);
+    var halfAxesInner = Matrix3.fromArray(boxInner, 3, scratchInnerHalfAxes);
+    centerInner = Matrix4.multiplyByPoint(transform, center, center);
+    var rotationScaleInner = Matrix4.getRotation(transform, scratchMatrixInner);
+    halfAxesInner = Matrix3.multiply(rotationScaleInner, halfAxesInner, halfAxesInner);
+
+    return (boxInner[0] >= boxOuter[0]) &&
+        (boxInner[1] >= boxOuter[1]) &&
+        (boxInner[2] <= boxOuter[2]) &&
+        (boxInner[3] <= boxOuter[3]) &&
+        (boxInner[4] >= boxOuter[4]) &&
+        (boxInner[5] >= boxOuter[5]) &&
+        (boxInner[6] <= boxOuter[6]) &&
+        (boxInner[7] <= boxOuter[7]);
 }

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -109,8 +109,8 @@ function validateTileHierarchy(root, tilesetDirectory) {
                 return 'content sphere [' + contentSphere + '] is not within tile sphere + [' + tileSphere + ']';
             }
 
-            if (defined(contentBox) && defined(tileBox) && !boxInsideBox(contentBox, tileBox, tile.transform)) {
-                return 'content box [' + contentBox + '] is not within tile box + [' + tileBox + ']';
+            if (defined(contentBox) && defined(tileBox) && !boxInsideBox(contentBox, tileBox)) {
+                return 'content box is not within tile box';
             }
         }
 

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -10,6 +10,7 @@ var validateTile = require('../lib/validateTile');
 
 var regionInsideRegion = utility.regionInsideRegion;
 var sphereInsideSphere = utility.sphereInsideSphere;
+var boxInsideBox = utility.boxInsideBox;
 
 var defined = Cesium.defined;
 
@@ -94,8 +95,11 @@ function validateTileHierarchy(root, tilesetDirectory) {
         if (defined(content) && defined(content.boundingVolume)) {
             var contentRegion = content.boundingVolume.region;
             var contentSphere = content.boundingVolume.sphere;
+            var contentBox = content.boundingVolume.box;
+
             var tileRegion = tile.boundingVolume.region;
             var tileSphere = tile.boundingVolume.sphere;
+            var tileBox = tile.boundingVolume.box;
 
             if (defined(contentRegion) && defined(tileRegion) && !regionInsideRegion(contentRegion, tileRegion)) {
                 return 'content region [' + contentRegion + '] is not within tile region + [' + tileRegion + ']';
@@ -103,6 +107,10 @@ function validateTileHierarchy(root, tilesetDirectory) {
 
             if (defined(contentSphere) && defined(tileSphere) && !sphereInsideSphere(contentSphere, tileSphere)) {
                 return 'content sphere [' + contentSphere + '] is not within tile sphere + [' + tileSphere + ']';
+            }
+
+            if (defined(contentBox) && defined(tileBox) && !boxInsideBox(contentBox, tileBox, tile.transform)) {
+                return 'content box [' + contentBox + '] is not within tile box + [' + tileBox + ']';
             }
         }
 

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -110,7 +110,7 @@ function validateTileHierarchy(root, tilesetDirectory) {
             }
 
             if (defined(contentBox) && defined(tileBox) && !boxInsideBox(contentBox, tileBox)) {
-                return 'content box is not within tile box';
+                return 'content box [' + contentBox + '] is not within tile box [' + tileBox + ']';
             }
         }
 

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -41,28 +41,28 @@ var sampleTileset = {
 };
 
 var sampleTileset2 = {
-    'asset': {
-        'version': '1.0'
+    asset: {
+        version: '1.0'
     },
-    'geometricError': 500,
-    'root': {
-        'transform': [96.86356343768793, 24.848542777253734, 0, 0,
+    geometricError: 500,
+    root: {
+        transform: [96.86356343768793, 24.848542777253734, 0, 0,
             -15.986465724980844, 62.317780594908875, 76.5566922962899, 0,
             19.02322243409411, -74.15554020821229, 64.3356267137516, 0,
             1215107.7612304366, -4736682.902037748, 4081926.095098698, 1
         ],
-        'boundingVolume': {
-            'box': [0, 0, 0,
+        boundingVolume: {
+            box: [0, 0, 0,
                 7.0955, 0, 0,
                 0, 3.1405, 0,
                 0, 0, 5.0375
             ]
         },
-        'geometricError': 100,
-        'refine': 'ADD',
-        'content': {
-            'boundingVolume': {
-                'box': [
+        geometricError: 100,
+        refine: 'ADD',
+        content: {
+            boundingVolume: {
+                box: [
                     0, 0, 0,
                     7.0955, 0, 0,
                     0, 3.1405, 0,

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -202,8 +202,8 @@ describe('validateTileset', function() {
                 expect(message).toBeUndefined();
             }), done).toResolve();
     });
-  
-  it('returns error message when content\'s box type boundingVolume is not within it\'s tile\'s sphere type boundingVolume', function(done) {
+
+    it('returns error message when content\'s box type boundingVolume is not within it\'s tile\'s sphere type boundingVolume', function(done) {
         var tileBoundingVolume = {
             sphere: [0, 0, 0, 1]
         };

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -133,7 +133,8 @@ describe('validateTileset', function() {
 
     it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [invalid aligned bounding boxes]', function(done) {
         var tileBoundingVolume = {
-            box: [0, 0, 0,
+            box: [
+                0, 0, 0,
                 7.0955, 0, 0,
                 0, 3.1405, 0,
                 0, 0, 5.0375
@@ -156,7 +157,8 @@ describe('validateTileset', function() {
 
     it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [invalid unaligned bounding boxes]', function(done) {
         var tileBoundingVolume = {
-            box: [0, 0, 0,
+            box: [
+                0, 0, 0,
                 1, 0, 0,
                 0, 1, 0,
                 0, 0, 1
@@ -177,9 +179,10 @@ describe('validateTileset', function() {
             }), done).toResolve();
     });
 
-    it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [valid bounding boxes]', function(done) {
+    it('succeeds when a content\'s box type boundingVolume is within it\'s tile\'s box type boundingVolume [valid bounding boxes]', function(done) {
         var tileBoundingVolume = {
-            box: [0, 0, 0,
+            box: [
+                0, 0, 0,
                 1, 0, 0,
                 0, 1, 0,
                 0, 0, 1
@@ -215,7 +218,8 @@ function createSampleTileset(tileBoundingVolume, contentBoundingVolume) {
         },
         geometricError: 500,
         root: {
-            transform: [96.86356343768793, 24.848542777253734, 0, 0,
+            transform: [
+                96.86356343768793, 24.848542777253734, 0, 0,
                 -15.986465724980844, 62.317780594908875, 76.5566922962899, 0,
                 19.02322243409411, -74.15554020821229, 64.3356267137516, 0,
                 1215107.7612304366, -4736682.902037748, 4081926.095098698, 1

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -40,39 +40,6 @@ var sampleTileset = {
     }
 };
 
-var sampleTileset2 = {
-    asset: {
-        version: '1.0'
-    },
-    geometricError: 500,
-    root: {
-        transform: [96.86356343768793, 24.848542777253734, 0, 0,
-            -15.986465724980844, 62.317780594908875, 76.5566922962899, 0,
-            19.02322243409411, -74.15554020821229, 64.3356267137516, 0,
-            1215107.7612304366, -4736682.902037748, 4081926.095098698, 1
-        ],
-        boundingVolume: {
-            box: [0, 0, 0,
-                7.0955, 0, 0,
-                0, 3.1405, 0,
-                0, 0, 5.0375
-            ]
-        },
-        geometricError: 100,
-        refine: 'ADD',
-        content: {
-            boundingVolume: {
-                box: [
-                    0, 0, 0,
-                    7.0955, 0, 0,
-                    0, 3.1405, 0,
-                    0, 0, 5.04
-                ]
-            }
-        }
-    }
-};
-
 describe('validateTileset', function() {
     it('returns error message when the geometricError is not defined', function(done) {
         var tileset = clone(sampleTileset, true);
@@ -164,11 +131,72 @@ describe('validateTileset', function() {
             }), done).toResolve();
     });
 
-    it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume', function(done) {
-        var tileset = clone(sampleTileset2, true);
+    it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [invalid aligned bounding boxes]', function(done) {
+        var tileBoundingVolume = {
+            box: [0, 0, 0,
+                7.0955, 0, 0,
+                0, 3.1405, 0,
+                0, 0, 5.0375
+            ]
+        };
+        var contentBoundingVolume = {
+            box: [
+                0, 0, 0,
+                7.0955, 0, 0,
+                0, 3.1405, 0,
+                0, 0, 5.04
+            ]
+        };
+        var tileset = createSampleTileset(tileBoundingVolume, contentBoundingVolume);
         expect(validateTileset(tileset)
             .then(function(message) {
-                expect(message).toBe('content box is not within tile box');
+                expect(message).toBe('content box [' + contentBoundingVolume.box + '] is not within tile box [' + tileBoundingVolume.box + ']');
+            }), done).toResolve();
+    });
+
+    it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [invalid unaligned bounding boxes]', function(done) {
+        var tileBoundingVolume = {
+            box: [0, 0, 0,
+                1, 0, 0,
+                0, 1, 0,
+                0, 0, 1
+            ]
+        };
+        var contentBoundingVolume = {
+            box: [
+                0, 0, 0,
+                1, 1, 0,
+                1, 1, 0,
+                0, 0, 1
+            ]
+        };
+        var tileset = createSampleTileset(tileBoundingVolume, contentBoundingVolume);
+        expect(validateTileset(tileset)
+            .then(function(message) {
+                expect(message).toBe('content box [' + contentBoundingVolume.box + '] is not within tile box [' + tileBoundingVolume.box + ']');
+            }), done).toResolve();
+    });
+
+    it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [valid bounding boxes]', function(done) {
+        var tileBoundingVolume = {
+            box: [0, 0, 0,
+                1, 0, 0,
+                0, 1, 0,
+                0, 0, 1
+            ]
+        };
+        var contentBoundingVolume = {
+            box: [
+                0, 0, 0,
+                0.5, 0.5, 0,
+                0.5, 0.5, 0,
+                0, 0, 1
+            ]
+        };
+        var tileset = createSampleTileset(tileBoundingVolume, contentBoundingVolume);
+        expect(validateTileset(tileset)
+            .then(function(message) {
+                expect(message).toBeUndefined();
             }), done).toResolve();
     });
 
@@ -179,3 +207,26 @@ describe('validateTileset', function() {
           }), done).toResolve();
     });
 });
+
+function createSampleTileset(tileBoundingVolume, contentBoundingVolume) {
+    var sampleTileset = {
+        asset: {
+            version: '1.0'
+        },
+        geometricError: 500,
+        root: {
+            transform: [96.86356343768793, 24.848542777253734, 0, 0,
+                -15.986465724980844, 62.317780594908875, 76.5566922962899, 0,
+                19.02322243409411, -74.15554020821229, 64.3356267137516, 0,
+                1215107.7612304366, -4736682.902037748, 4081926.095098698, 1
+            ],
+            boundingVolume: tileBoundingVolume,
+            geometricError: 100,
+            refine: 'ADD',
+            content: {
+                boundingVolume: contentBoundingVolume
+            }
+        }
+    };
+    return sampleTileset;
+}

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -40,6 +40,39 @@ var sampleTileset = {
     }
 };
 
+var sampleTileset2 = {
+    'asset': {
+        'version': '1.0'
+    },
+    'geometricError': 500,
+    'root': {
+        'transform': [96.86356343768793, 24.848542777253734, 0, 0,
+            -15.986465724980844, 62.317780594908875, 76.5566922962899, 0,
+            19.02322243409411, -74.15554020821229, 64.3356267137516, 0,
+            1215107.7612304366, -4736682.902037748, 4081926.095098698, 1
+        ],
+        'boundingVolume': {
+            'box': [0, 0, 0,
+                7.0955, 0, 0,
+                0, 3.1405, 0,
+                0, 0, 5.0375
+            ]
+        },
+        'geometricError': 100,
+        'refine': 'ADD',
+        'content': {
+            'boundingVolume': {
+                'box': [
+                    0, 0, 0,
+                    7.0955, 0, 0,
+                    0, 3.1405, 0,
+                    0, 0, 5.04
+                ]
+            }
+        }
+    }
+};
+
 describe('validateTileset', function() {
     it('returns error message when the geometricError is not defined', function(done) {
         var tileset = clone(sampleTileset, true);
@@ -128,6 +161,14 @@ describe('validateTileset', function() {
         expect(validateTileset(tileset)
             .then(function(message) {
                 expect(message).toBe('gltfUpAxis should either be "X", "Y", or "Z".');
+            }), done).toResolve();
+    });
+
+    it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume', function(done) {
+        var tileset = clone(sampleTileset2, true);
+        expect(validateTileset(tileset)
+            .then(function(message) {
+                expect(message).toBe('content box is not within tile box');
             }), done).toResolve();
     });
 


### PR DESCRIPTION
Issue #25 - Box inside box

@lilleyse, According to the [3D tiles readme](https://github.com/AnalyticalGraphicsInc/3d-tiles#tile-transform), tile.transform applies to both - the tile's bounding box, and its content's bounding box. So, to check if one is inside the other, the transform should not affect the result. 

So, I have neglected transform for the check. I am converting the half axes representation of the boxes to a diagonal representation, and comparing both the boxes directly, assuming they have the same orientation.

Also, there was a minor spelling error in sphere inside sphere check, which I have corrected here.