### PR TITLE
upgrade: support relative url in tile file

### DIFF
--- a/tools/lib/optimizeGlb.js
+++ b/tools/lib/optimizeGlb.js
@@ -39,7 +39,7 @@ function optimizeGlb(glbBuffer, options) {
         }
     }
     fixBatchIdSemantic(gltf);
-    return loadGltfUris(gltf)
+    return loadGltfUris(gltf, options)
         .then(function() {
             return Pipeline.processJSONWithExtras(gltf, options)
                 .then(function(gltf) {

--- a/tools/lib/upgradeTileset.js
+++ b/tools/lib/upgradeTileset.js
@@ -92,22 +92,22 @@ var optimizeOptions = {
 function upgradeTile(file) {
     return readFile(file)
         .then(function(buffer) {
-            return upgradeTileContent(buffer);
+            return upgradeTileContent(buffer, path.dirname(file));
         });
 }
 
-function upgradeTileContent(buffer) {
+function upgradeTileContent(buffer, basePath) {
     var magic = getMagic(buffer);
     if (magic === 'b3dm') {
         var b3dm = extractB3dm(buffer);
-        return optimizeGlb(b3dm.glb, optimizeOptions)
+        return optimizeGlb(b3dm.glb, Object.assign({}, optimizeOptions, {basePath: basePath}))
             .then(function(glb) {
                 return glbToB3dm(glb, b3dm.featureTable.json, b3dm.featureTable.binary, b3dm.batchTable.json, b3dm.batchTable.binary);
             });
     } else if (magic === 'cmpt') {
         var tiles = extractCmpt(buffer);
         return Promise.map(tiles, function(tile) {
-            return upgradeTileContent(tile);
+            return upgradeTileContent(tile, basePath);
         }).then(function(upgradedTiles) {
             return makeCompositeTile(upgradedTiles);
         });


### PR DESCRIPTION
This patch to solve the problem that when there is relative url in tile file, the upgrade procedure will fail with following message:

```
glTF model references external files but no basePath is supplied
```

which is raised from [here](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/blob/f58a3a87234affe2f1c5961ed894ed3c310fd992/lib/loadGltfUris.js#L100)