### PR TITLE
Remove tilesetVersion from certain tilest

### DIFF
--- a/samples-generator/bin/3d-tiles-samples-generator.js
+++ b/samples-generator/bin/3d-tiles-samples-generator.js
@@ -1312,8 +1312,7 @@ function createTilesetWithExternalResources() {
 
     var tilesetJson = {
         asset : {
-            version : '1.0',
-            tilesetVersion : '1.2.3'
+            version : '1.0'
         },
         geometricError : smallGeometricError,
         root : {


### PR DESCRIPTION
Removes `tilesetVersion` from `TilesetWithExternalResources`. Only `Tileset` needs to set `tilesetVersion` for Cesium's testing purposes.

@shehzan10 can you review?