### PR TITLE
Added extras dictionary to tileset

### DIFF
--- a/samples-generator/bin/3d-tiles-samples-generator.js
+++ b/samples-generator/bin/3d-tiles-samples-generator.js
@@ -1049,6 +1049,9 @@ function createTileset() {
             version : '1.0',
             tilesetVersion : '1.2.3'
         },
+        extras : {
+            name : 'Sample Tileset'
+        },
         properties : undefined,
         geometricError : largeGeometricError,
         root : {
@@ -1080,7 +1083,10 @@ function createTileset() {
                     geometricError : 0.0,
                     content : {
                         url : 'lr.b3dm'
-                    }
+                    },
+                    extras : {
+                        id : 'Special Tile'
+                    },
                 },
                 {
                     boundingVolume : {


### PR DESCRIPTION
This PR adds an `extras` dictionary to the tileset as well as to one of the children. This is to test adding support for `extras` in CesiumJS (https://github.com/AnalyticalGraphicsInc/cesium/pull/6974).