### PR TITLE
Add extras dictionary to tileset

### DIFF
--- a/samples-generator/bin/3d-tiles-samples-generator.js
+++ b/samples-generator/bin/3d-tiles-samples-generator.js
@@ -1017,6 +1017,9 @@ function createTileset() {
             version : versionNumber,
             tilesetVersion : '1.2.3'
         },
+        extras : {
+            name : 'Sample Tileset'
+        },
         properties : undefined,
         geometricError : largeGeometricError,
         root : {
@@ -1048,6 +1051,9 @@ function createTileset() {
                     geometricError : 0.0,
                     content : {
                         uri : 'lr.b3dm'
+                    },
+                    extras : {
+                        id : 'Special Tile'
                     }
                 },
                 {


### PR DESCRIPTION
This PR adds an extras dictionary to the tileset as well as to one of the children. This is to test adding support for extras in CesiumJS (AnalyticalGraphicsInc/cesium#6974).

I branched off of `2.0-samples-generator` to get the updates in that PR (https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/pull/139).