### PR TITLE
Revert some tileset changes

### DIFF
--- a/samples-generator/bin/3d-tiles-samples-generator.js
+++ b/samples-generator/bin/3d-tiles-samples-generator.js
@@ -1158,7 +1158,8 @@ function createTilesetOfTilesets() {
 
     var tilesetJson = {
         asset : {
-            version : versionNumber
+            version : versionNumber,
+            tilesetVersion : '1.2.3'
         },
         properties : undefined,
         geometricError : largeGeometricError,
@@ -1166,7 +1167,7 @@ function createTilesetOfTilesets() {
             boundingVolume : {
                 region : parentRegion
             },
-            geometricError : largeGeometricError,
+            geometricError : smallGeometricError,
             refine : 'ADD',
             content : {
                 uri : 'tileset2.json'
@@ -1193,7 +1194,7 @@ function createTilesetOfTilesets() {
                     boundingVolume : {
                         region : llRegion
                     },
-                    geometricError : smallGeometricError,
+                    geometricError : 0.0,
                     content : {
                         uri : 'tileset3/tileset3.json'
                     }


### PR DESCRIPTION
Reverts https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/pull/151 since the test in Cesium now expects the root to have `tilesetVersion` [here](https://github.com/AnalyticalGraphicsInc/cesium/pull/6933/files#diff-f6d818b2e2d0c6220e3e656e15905620R1293)

Reverts https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/pull/140 which was accidentally hiding incorrect behavior fixed in https://github.com/AnalyticalGraphicsInc/cesium/pull/7035. In general a `.json` tile should have the same geometric error as the external tileset root tile. I left the tileset-level geometric errors the same since those shouldn't match the root tile's geometric error.