### PR TITLE
Add glTF 2.0 validation

### DIFF
--- a/validator/bin/3d-tiles-validator.js
+++ b/validator/bin/3d-tiles-validator.js
@@ -12,7 +12,7 @@ var validateTileset = require('../lib/validateTileset');
 var defined = Cesium.defined;
 
 var args = process.argv.slice(2);
-var argv = yargs
+global.argv = yargs
     .usage('Usage: node $0 -i <path>')
     .help('h')
     .alias('h', 'help')
@@ -23,6 +23,12 @@ var argv = yargs
             normalize: true,
             demandOption: true,
             type: 'string'
+        },
+        'r': {
+            alias: 'writeReports',
+            description: 'Write glTF error reports next to the glTF file in question.',
+            default: false,
+            type: 'boolean'
         }
     })
     .recommendCommands()

--- a/validator/bin/3d-tiles-validator.js
+++ b/validator/bin/3d-tiles-validator.js
@@ -39,12 +39,12 @@ if (extension === '') {
 if (isTile(filePath)) {
     promise = readTile(filePath)
         .then(function(content) {
-            return validateTile(content);
+            return validateTile(content, filePath);
         });
 } else {
     promise = readTileset(filePath)
         .then(function(tileset) {
-            return validateTileset(tileset, path.dirname(filePath));
+            return validateTileset(tileset, filePath, path.dirname(filePath));
         });
 }
 

--- a/validator/lib/validateB3dm.js
+++ b/validator/lib/validateB3dm.js
@@ -26,7 +26,7 @@ var featureTableSemantics = {
  * @param {Buffer} content A buffer containing the contents of a b3dm tile.
  * @returns {String} An error message if validation fails, otherwise undefined.
  */
-function validateB3dm(content) {
+function validateB3dm(content, filePath) {
     var headerByteLength = 28;
     if (content.length < headerByteLength) {
         return 'Header must be 28 bytes.';
@@ -123,7 +123,7 @@ function validateB3dm(content) {
         return batchTableMessage;
     }
 
-    var glbMessage = validateGlb(glbBuffer);
+    var glbMessage = validateGlb(glbBuffer, filePath + ".glb");
     if (defined(glbMessage)) {
         return glbMessage;
     }

--- a/validator/lib/validateBatchTable.js
+++ b/validator/lib/validateBatchTable.js
@@ -1,10 +1,12 @@
 'use strict';
-var Ajv = require('ajv');
+var djv = require('djv');
 var Cesium = require('cesium');
 var utility = require('./utility');
 
 var componentTypeToByteLength = utility.componentTypeToByteLength;
 var typeToComponentsLength = utility.typeToComponentsLength;
+var extrasSchema = require('../specs/data/schema/extras.schema.json');
+var extensionSchema = require('../specs/data/schema/extension.schema.json');
 
 var defined = Cesium.defined;
 
@@ -70,9 +72,12 @@ function validateBatchTable(schema, batchTableJson, batchTableBinary, featuresLe
         }
     }
 
-    var ajv = new Ajv();
-    var validSchema = ajv.validate(schema, batchTableJson);
-    if (!validSchema) {
-        return 'Batch table JSON failed schema validation: ' + ajv.errorsText();
+    const env = new djv({ version: 'draft-04' });
+    env.addSchema('extras.schema.json', extrasSchema);
+    env.addSchema('extension.schema.json', extensionSchema);
+    env.addSchema('batchTable.schema.json', schema);
+    var validSchema = env.validate('batchTable.schema.json', batchTableJson);
+    if (validSchema !== undefined) {
+        return 'Batch table JSON failed schema validation: ' + validSchema;
     }
 }

--- a/validator/lib/validateCmpt.js
+++ b/validator/lib/validateCmpt.js
@@ -14,7 +14,7 @@ module.exports = validateCmpt;
  * @param {Buffer} content A buffer containing the contents of a cmpt tile.
  * @returns {String} An error message if validation fails, otherwise undefined.
  */
-function validateCmpt(content) {
+function validateCmpt(content, filePath) {
     var headerByteLength = 16;
     if (content.length < headerByteLength) {
         return 'Header must be 16 bytes.';

--- a/validator/lib/validateFeatureTable.js
+++ b/validator/lib/validateFeatureTable.js
@@ -1,5 +1,5 @@
 'use strict';
-var Ajv = require('ajv');
+var djv = require('djv');
 var Cesium = require('cesium');
 var utility = require('./utility');
 
@@ -8,6 +8,8 @@ var typeToComponentsLength = utility.typeToComponentsLength;
 
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
+var extrasSchema = require('../specs/data/schema/extras.schema.json');
+var extensionSchema = require('../specs/data/schema/extension.schema.json');
 
 module.exports = validateFeatureTable;
 
@@ -79,9 +81,12 @@ function validateFeatureTable(schema, featureTableJson, featureTableBinary, feat
         }
     }
 
-    var ajv = new Ajv();
-    var validSchema = ajv.validate(schema, featureTableJson);
-    if (!validSchema) {
-        return 'Feature table JSON failed schema validation: ' + ajv.errorsText();
+    const env = new djv({ version: 'draft-04' });
+    env.addSchema('extras.schema.json', extrasSchema);
+    env.addSchema('extension.schema.json', extensionSchema);
+    env.addSchema('featureTable.schema.json', schema);
+    var validSchema = env.validate('featureTable.schema.json', featureTableJson);
+    if (validSchema !== undefined) {
+        return 'Feature table JSON failed schema validation: ' + validSchema;
     }
 }

--- a/validator/lib/validateGlb.js
+++ b/validator/lib/validateGlb.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = validateGlb;
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const validator = require('gltf-validator');
 
 /**
  * Check if the glb is valid binary glTF.
@@ -8,10 +12,44 @@ module.exports = validateGlb;
  * @param {Buffer} glb The glb buffer.
  * @returns {String} An error message if validation fails, otherwise undefined.
  */
-function validateGlb(glb) {
+function validateGlb(glb, filePath) {
     var version = glb.readUInt32LE(4);
 
     if (version !== 2) {
         return 'Invalid Glb version: ' + version + '. Version must be 2.';
     }
+
+    return validator.validateBytes(glb, {
+        uri: filePath,
+        externalResourceFunction: (uri) =>
+            new Promise((resolve, reject) => {
+                uri = path.resolve(path.dirname(filePath), decodeURIComponent(uri));
+                console.info("Loading external file: " + uri);
+                fs.readFile(uri, (err, data) => {
+                    if (err) {
+                        console.error(err.toString());
+                        reject(err.toString());
+                        return;
+                    }
+                    resolve(data);
+                });
+            })
+    }).then((result) => {
+        // [result] will contain validation report in object form.
+        // You can convert it to JSON to see its internal structure. 
+        if (result.issues.numErrors > 0) {
+            let validationText = JSON.stringify(result, null, '  ');
+            //fs.writeFile(`${filePath}_report.json`, validationText, (err) => {
+            //    if (err) { throw err; }
+            //});
+            return validationText;
+        }
+        return;
+    }, (result) => {
+        // Promise rejection means that arguments were invalid or validator was unable 
+        // to detect file format (glTF or GLB). 
+        // [result] will contain exception string.
+        //console.error(result);
+        return result;
+    });
 }

--- a/validator/lib/validateGlb.js
+++ b/validator/lib/validateGlb.js
@@ -39,9 +39,11 @@ function validateGlb(glb, filePath) {
         // You can convert it to JSON to see its internal structure. 
         if (result.issues.numErrors > 0) {
             let validationText = JSON.stringify(result, null, '  ');
-            //fs.writeFile(`${filePath}_report.json`, validationText, (err) => {
-            //    if (err) { throw err; }
-            //});
+            if (argv.writeReports) {
+                fs.writeFile(`${filePath}_report.json`, validationText, (err) => {
+                    if (err) { throw err; }
+                });
+            }
             return validationText;
         }
         return;

--- a/validator/lib/validateI3dm.js
+++ b/validator/lib/validateI3dm.js
@@ -94,7 +94,7 @@ var featureTableSemantics = {
  * @param {Buffer} content A buffer containing the contents of an i3dm tile.
  * @returns {String} An error message if validation fails, otherwise undefined.
  */
-function validateI3dm(content) {
+function validateI3dm(content, filePath) {
     var headerByteLength = 32;
     if (content.length < headerByteLength) {
         return 'Header must be 32 bytes.';

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -94,7 +94,7 @@ var featureTableSemantics = {
  * @param {Buffer} content A buffer containing the contents of a pnts tile.
  * @returns {String} An error message if validation fails, otherwise undefined.
  */
-function validatePnts(content) {
+function validatePnts(content, filePath) {
     var headerByteLength = 28;
     if (content.length < headerByteLength) {
         return 'Header must be 28 bytes.';

--- a/validator/lib/validateTile.js
+++ b/validator/lib/validateTile.js
@@ -12,19 +12,19 @@ module.exports = validateTile;
  * @param {Buffer} content The tile's content.
  * @returns {String} An error message if validation fails, otherwise undefined.
  */
-function validateTile(content) {
+function validateTile(content, filePath) {
     if (content.length < 4) {
         return 'Cannot determine tile format from tile header, tile content is ' + content.length + ' bytes.';
     }
     var magic = content.toString('utf8', 0, 4);
     if (magic === 'b3dm') {
-        return validateB3dm(content);
+        return validateB3dm(content, filePath);
     } else if (magic === 'i3dm') {
-        return validateI3dm(content);
+        return validateI3dm(content, filePath);
     } else if (magic === 'pnts') {
-        return validatePnts(content);
+        return validatePnts(content, filePath);
     } else if (magic === 'cmpt') {
-        return validateCmpt(content);
+        return validateCmpt(content, filePath);
     }
     return 'Invalid magic: ' + magic;
 }

--- a/validator/package.json
+++ b/validator/package.json
@@ -24,21 +24,23 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cesium": "^1.34",
-    "fs-extra": "^3.0.1"
+    "djv": "^2.1.3-alpha.0",
+    "fs-extra": "^3.0.1",
+    "gltf-validator": "^2.0.0-dev.2.7"
   },
   "devDependencies": {
     "clone": "^2.1.1",
     "eslint": "^4.1.1",
     "eslint-config-cesium": "^2.0.0",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "jasmine": "^2.6.0",
     "jasmine-spec-reporter": "^4.1.1",
     "jsdoc": "^3.4.3",
-    "nyc": "^11.0.3",
-    "open": "^0.0.5",
+    "nyc": "^14.1.1",
+    "open": "^7.0.0",
     "request": "^2.81.0",
     "requirejs": "^2.3.3",
-    "yargs": "^8.0.2"
+    "yargs": "^15.0.2"
   },
   "scripts": {
     "eslint": "eslint \"./**/*.js\" --cache --quiet",

--- a/validator/specs/data/schema/asset.schema.json
+++ b/validator/specs/data/schema/asset.schema.json
@@ -7,17 +7,17 @@
     "properties" : {
         "version" : {
             "type" : "string",
-            "description" : "The 3D Tiles version.  The version defines the JSON schema for tileset.json and the base set of tile formats."
+            "description" : "The 3D Tiles version.  The version defines the JSON schema for the tileset JSON and the base set of tile formats."
         },
         "tilesetVersion" : {
             "type" : "string",
             "description" : "Application-specific version of this tileset, e.g., for when an existing tileset is updated."
         },
-        "gltfUpAxis" : {
-            "type" : "string",
-            "description" : "Specifies the up-axis of glTF models.",
-            "enum" : ["X", "Y", "Z"],
-            "default" : "Y"
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
     "required" : ["version"],

--- a/validator/specs/data/schema/b3dm.featureTable.schema.json
+++ b/validator/specs/data/schema/b3dm.featureTable.schema.json
@@ -9,10 +9,24 @@
     }, {
         "properties" : {
             "BATCH_LENGTH" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                "description": "A `GlobalPropertyScalar` object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                }]
+            },
+            "RTC_CENTER" : {
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
+            },
+            "extensions" : {
+                "$ref": "extension.schema.json"
+            },
+            "extras" : {
+                "$ref": "extras.schema.json"
             }
         },
-        "required" : ["BATCH_LENGTH"],
-        "additionalProperties" : false
+        "required" : ["BATCH_LENGTH"]
     }]
 }

--- a/validator/specs/data/schema/batchTable.schema.json
+++ b/validator/specs/data/schema/batchTable.schema.json
@@ -5,8 +5,11 @@
     "type" : "object",
     "description" : "A set of properties defining application-specific metadata for features in a tile.",
     "properties" : {
-        "HIERARCHY" : {
-            "$ref" : "#/definitions/hierarchy"
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
     "additionalProperties" : {
@@ -14,96 +17,35 @@
     },
     "definitions" : {
         "binaryBodyReference" : {
+            "title" : "BinaryBodyReference",
             "type" : "object",
+            "description" : "An object defining the reference to a section of the binary body of the batch table where the property values are stored if not defined directly in the JSON.",
             "properties" : {
                 "byteOffset" : {
-                    "type" : "integer",
+                    "type" : "number",
+                    "description": "The offset into the buffer in bytes.",
                     "minimum" : 0
                 },
                 "componentType" : {
                     "type" : "string",
+                    "description": "The datatype of components in the property.",
                     "enum" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "DOUBLE"]
                 },
                 "type" : {
                     "type" : "string",
+                    "description": "Specifies if the property is a scalar or vector.",
                     "enum" : ["SCALAR", "VEC2", "VEC3", "VEC4"]
                 }
             },
             "required" : ["byteOffset", "componentType", "type"]
         },
         "property" : {
-            "anyOf" : [
+            "title" : "Property",
+            "description" : "A user-defined property which specifies per-feature application-specific metadata in a tile. Values either can be defined directly in the JSON as an array, or can refer to sections in the binary body with a `BinaryBodyReference` object.",
+            "oneOf" : [
                 { "$ref" : "#/definitions/binaryBodyReference" },
-                { "type" : "array" }
+                { "type" : "array"}
             ]
-        },
-        "integerArray" : {
-            "type" : "array",
-            "items" : {
-                "type" : "number",
-                "minimum" : 0
-            }
-        },
-        "integerBinaryBodyReference" : {
-            "type" : "object",
-            "properties" : {
-                "byteOffset" : {
-                    "type" : "integer",
-                    "minimum" : 0
-                },
-                "componentType" : {
-                    "type" : "string",
-                    "enum" : ["UNSIGNED_BYTE", "UNSIGNED_SHORT", "UNSIGNED_INT"]
-                }
-            },
-            "required" : ["byteOffset"]
-        },
-        "integerProperty" : {
-            "anyOf" : [
-                { "$ref" : "#/definitions/integerBinaryBodyReference" },
-                { "$ref" : "#/definitions/integerArray" }
-            ]
-        },
-        "hierarchy" : {
-            "type" : "object",
-            "properties" : {
-                "classes" : {
-                    "type" : "array",
-                    "items" : {
-                        "type" : "object",
-                        "properties" : {
-                            "name" : {
-                                "type" : "string"
-                            },
-                            "length" : {
-                                "type" : "number",
-                                "minimum" : 0
-                            },
-                            "instances" : {
-                                "type" : "object",
-                                "additionalProperties" : {
-                                    "$ref" : "#/definitions/property"
-                                }
-                            }
-                        },
-                        "required" : ["name", "length", "instances"]
-                    }
-                },
-                "instancesLength" : {
-                    "type" : "number",
-                    "minimum" : 0
-                },
-                "classIds" : {
-                    "$ref" : "#/definitions/integerProperty"
-                },
-                "parentCounts" : {
-                    "$ref" : "#/definitions/integerProperty"
-                },
-                "parentIds" : {
-                    "$ref" : "#/definitions/integerProperty"
-                }
-            },
-            "required" : ["classes", "instancesLength", "classIds"]
         }
     }
 }

--- a/validator/specs/data/schema/boundingVolume.schema.json
+++ b/validator/specs/data/schema/boundingVolume.schema.json
@@ -3,7 +3,7 @@
     "id" : "boundingVolume.schema.json",
     "title" : "Bounding Volume",
     "type" : "object",
-    "description" : "A bounding volume that encloses a tile or its contents.  Exactly one property is required.",
+    "description" : "A bounding volume that encloses a tile or its content.  Exactly one `box`, `region`, or `sphere` property is required.",
     "properties" : {
         "box" : {
             "type" : "array",
@@ -16,7 +16,7 @@
         },
         "region" : {
             "type" : "array",
-            "description" : "An array of six numbers that define a bounding geographic region in WGS84 / EPSG:4326 coordinates with the order [west, south, east, north, minimum height, maximum height]. Longitudes and latitudes are in radians, and heights are in meters above (or below) the WGS84 ellipsoid.",
+            "description" : "An array of six numbers that define a bounding geographic region in EPSG:4979 coordinates with the order [west, south, east, north, minimum height, maximum height]. Longitudes and latitudes are in radians, and heights are in meters above (or below) the WGS84 ellipsoid.",
             "items" : {
                 "type" : "number"
             },
@@ -31,6 +31,12 @@
             },
             "minItems" : 4,
             "maxItems" : 4
+        },
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
     "oneOf" : [{

--- a/validator/specs/data/schema/extension.schema.json
+++ b/validator/specs/data/schema/extension.schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Extension",
+    "type": "object",
+    "description": "Dictionary object with extension-specific objects.",
+    "properties": {},
+    "additionalProperties": {
+        "type": "object"
+    }
+}

--- a/validator/specs/data/schema/extras.schema.json
+++ b/validator/specs/data/schema/extras.schema.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Extras",
+    "description": "Application-specific data."
+}

--- a/validator/specs/data/schema/featureTable.schema.json
+++ b/validator/specs/data/schema/featureTable.schema.json
@@ -6,11 +6,19 @@
     "description" : "A set of semantics containing per-tile and per-feature values defining the position and appearance properties for features in a tile.",
     "definitions" : {
         "binaryBodyReference" : {
+            "title" : "BinaryBodyReference",
             "type" : "object",
+            "description" : "An object defining the reference to a section of the binary body of the features table where the property values are stored if not defined directly in the JSON.",
             "properties" : {
                 "byteOffset" : {
-                    "type" : "integer",
+                    "type" : "number",
+                    "description": "The offset into the buffer in bytes.",
                     "minimum" : 0
+                },
+                "componentType" : {
+                    "type" : "number",
+                    "description": "The datatype of components in the property. This is defined only if the semantic allows for overriding the implicit component type. These cases are specified in each tile format.",
+                    "enum" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "DOUBLE"]
                 }
             },
             "required" : ["byteOffset"]
@@ -21,44 +29,106 @@
                 "type" : "number"
             }
         },
-        "globalPropertyScalar" : {
-            "oneOf" : [{
-                "$ref" : "#/definitions/binaryBodyReference"
-            }, {
-                "allOf" : [{
-                    "$ref" : "#/definitions/numericArray"
+        "property" : {
+            "title" : "Property",
+            "description" : "A user-defined property which specifies per-feature application-specific metadata in a tile. Values either can be defined directly in the JSON as an array, or can refer to sections in the binary body with a `BinaryBodyReference` object.",
+            "oneOf" : [
+                {
+                    "$ref" : "#/definitions/binaryBodyReference"
                 }, {
-                    "minItems" : 1,
-                    "maxItems" : 1
-                }]
+                    "type" : "array",
+                    "items" : {
+                        "type" : "number"
+                    }
+                }, {
+                    "type" : "number"
+                }
+            ]
+        },
+        "globalPropertyBoolean" : {
+            "title": "GlobalPropertyBoolean",
+            "description": "An object defining a global boolean property value for all features.",
+            "type" : "boolean"
+        },
+        "globalPropertyScalar" : {
+            "title": "GlobalPropertyScalar",
+            "description": "An object defining a global numeric property value for all features.",
+            "oneOf" : [{
+                "type" : "object",
+                "properties" : {
+                    "byteOffset" : {
+                        "type" : "number",
+                        "description": "The offset into the buffer in bytes.",
+                        "minimum" : 0
+                    }
+                },
+                "required" : ["byteOffset"]
             }, {
-                "type" : "integer",
+                "type" : "array",
+                "items" : {
+                    "type" : "number"
+                },
+                "minItems" : 1,
+                "maxItems" : 1
+            }, {
+                "type" : "number",
                 "minimum" : 0
             }]
         },
         "globalPropertyCartesian3" : {
+            "title": "GlobalPropertyCartesian3",
+            "description": "An object defining a global 3-component numeric property values for all features.",
             "oneOf" : [{
-                "$ref" : "#/definitions/binaryBodyReference"
+                "type" : "object",
+                "properties" : {
+                    "byteOffset" : {
+                        "type" : "number",
+                        "description": "The offset into the buffer in bytes.",
+                        "minimum" : 0
+                    }
+                },
+                "required" : ["byteOffset"]
             }, {
-                "allOf" : [{
-                    "$ref": "#/definitions/numericArray"
-                }, {
-                    "minItems" : 3,
-                    "maxItems" : 3
-                }]
+                "type" : "array",
+                "items" : {
+                    "type" : "number"
+                },
+                "minItems" : 3,
+                "maxItems" : 3
             }]
         },
         "globalPropertyCartesian4" : {
+            "title": "GlobalPropertyCartesian4",
+            "description": "An object defining a global 4-component numeric property values for all features.",
             "oneOf" : [{
-                "$ref" : "#/definitions/binaryBodyReference"
+                "type" : "object",
+                "properties" : {
+                    "byteOffset" : {
+                        "type" : "number",
+                        "description": "The offset into the buffer in bytes.",
+                        "minimum" : 0
+                    }
+                },
+                "required" : ["byteOffset"]
             }, {
-                "allOf": [{
-                    "$ref": "#/definitions/numericArray"
-                }, {
-                    "minItems": 4,
-                    "maxItems": 4
-                }]
+                "type" : "array",
+                "items" : {
+                    "type" : "number"
+                },
+                "minItems": 4,
+                "maxItems": 4
             }]
         }
+    },
+    "properties" : {
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    },
+    "additionalProperties" : {
+        "$ref" : "#/definitions/property"
     }
 }

--- a/validator/specs/data/schema/i3dm.featureTable.schema.json
+++ b/validator/specs/data/schema/i3dm.featureTable.schema.json
@@ -9,43 +9,97 @@
     }, {
         "properties" : {
             "POSITION" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "POSITION_QUANTIZED" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "NORMAL_UP" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "NORMAL_RIGHT" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "NORMAL_UP_OCT32P" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "NORMAL_RIGHT_OCT32P" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "SCALE" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "SCALE_NON_UNIFORM" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "BATCH_ID" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "INSTANCES_LENGTH" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                "description": "A `GlobalPropertyScalar` object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                }]
+            },
+            "RTC_CENTER" : {
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
             },
             "QUANTIZED_VOLUME_OFFSET" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
             },
-            "QUANTIZED_VOLUME_SCALE": {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+            "QUANTIZED_VOLUME_SCALE" : {
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
+            },
+            "EAST_NORTH_UP" : {
+                "description": "A `GlobalPropertyBoolean` object defining a boolean property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyBoolean"
+                }]
+            },
+            "extensions" : {
+                "$ref": "extension.schema.json"
+            },
+            "extras" : {
+                "$ref": "extras.schema.json"
             }
         },
-        "anyOf" : [{
+        "oneOf" : [{
           "required" : ["POSITION"]
         }, {
           "required" : ["POSITION_QUANTIZED"]
@@ -60,7 +114,6 @@
             "NORMAL_UP_OCT32P" : ["NORMAL_RIGHT_OCT32P"],
             "NORMAL_RIGHT_OCT32P" : ["NORMAL_UP_OCT32P"]
         },
-        "required" : ["INSTANCES_LENGTH"],
-        "additionalProperties" : false
+        "required" : ["INSTANCES_LENGTH"]
     }]
 }

--- a/validator/specs/data/schema/pnts.featureTable.schema.json
+++ b/validator/specs/data/schema/pnts.featureTable.schema.json
@@ -9,46 +9,94 @@
     }, {
         "properties" : {
             "POSITION" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "POSITION_QUANTIZED": {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "RGBA" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "RGB" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "RGB565" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "NORMAL" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "NORMAL_OCT16P" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "BATCH_ID" : {
-                "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/binaryBodyReference"
+                }]
             },
             "POINTS_LENGTH" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                "description": "A `GlobalPropertyScalar` object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                }]
             },
             "RTC_CENTER" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
             },
             "QUANTIZED_VOLUME_OFFSET" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
             },
             "QUANTIZED_VOLUME_SCALE" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                }]
             },
             "CONSTANT_RGBA" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian3"
+                "description": "A `GlobalPropertyCartesian4` object defining a 4-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyCartesian4"
+                }]
             },
             "BATCH_LENGTH" : {
-                "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                "description": "A `GlobalPropertyScalar` object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "allOf" : [{
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                }]
+            },
+            "extensions" : {
+                "$ref": "extension.schema.json"
+            },
+            "extras" : {
+                "$ref": "extras.schema.json"
             }
         },
         "anyOf" : [{
@@ -65,7 +113,6 @@
                 "BATCH_LENGTH"
             ]
         },
-        "required" : ["POINTS_LENGTH"],
-        "additionalProperties": false
+        "required" : ["POINTS_LENGTH"]
     }]
 }

--- a/validator/specs/data/schema/properties.schema.json
+++ b/validator/specs/data/schema/properties.schema.json
@@ -12,6 +12,12 @@
         "minimum" : {
             "type" : "number",
             "description" : "The minimum value of this property of all the features in the tileset."
+        },
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
     "required" : ["maximum", "minimum"],

--- a/validator/specs/data/schema/tile.content.schema.json
+++ b/validator/specs/data/schema/tile.content.schema.json
@@ -6,14 +6,20 @@
     "description" : "Metadata about the tile's content and a link to the content.",
     "properties" : {
         "boundingVolume" : {
-            "description" : "An optional bounding volume that tightly encloses just the tile's contents. This is used for replacement refinement; tile.boundingVolume provides spatial coherence and tile.content.boundingVolume enables tight view frustum culling. When this is omitted, tile.boundingVolume is used.",
+            "description" : "An optional bounding volume that tightly encloses just the tile's content. tile.boundingVolume provides spatial coherence and tile.content.boundingVolume enables tight view frustum culling. When this is omitted, tile.boundingVolume is used.",
             "$ref" : "boundingVolume.schema.json"
         },
-        "url" : {
+        "uri" : {
             "type" : "string",
-            "description" : "A string that points to the tile's contents with an absolute or relative url. When the url is relative, it is relative to the referring tileset.json. The file extension of content.url defines the tile format. The core 3D Tiles spec supports the following tile formats: Batched 3D Model (*.b3dm), Instanced 3D Model (*.i3dm), Composite (*.cmpt), and 3D Tiles TileSet (*.json)"
+            "description" : "A uri that points to the tile's content. When the uri is relative, it is relative to the referring tileset JSON file."
+        },
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
-    "required" : ["url"],
+    "required" : ["uri"],
     "additionalProperties" : false
 }

--- a/validator/specs/data/schema/tile.schema.json
+++ b/validator/specs/data/schema/tile.schema.json
@@ -10,12 +10,12 @@
             "$ref" : "boundingVolume.schema.json"
         },
         "viewerRequestVolume" : {
-            "extends" : { "$ref" : "boundingVolume.schema.json" },
-            "description" : "Optional bounding volume that defines the volume that the viewer must be inside of before the tile's content will be requested and before the tile will be refined based on geometricError."
+            "description" : "Optional bounding volume that defines the volume the viewer must be inside of before the tile's content will be requested and before the tile will be refined based on geometricError.",
+            "$ref" : "boundingVolume.schema.json"
         },
         "geometricError" : {
             "type" : "number",
-            "description" : "The error, in meters, introduced if this tile is rendered and its children are not. At runtime, the geometric error is used to compute Screen-Space Error (SSE), i.e., the error measured in pixels.",
+            "description" : "The error, in meters, introduced if this tile is rendered and its children are not. At runtime, the geometric error is used to compute screen space error (SSE), i.e., the error measured in pixels.",
             "minimum" : 0
         },
         "refine" : {
@@ -25,7 +25,7 @@
         },
         "transform" : {
             "type" : "array",
-            "description" : "A floating-point 4x4 affine transformation matrix, stored in column-major order, that transforms the tile's content, i.e., its features and content.boundingVolume, and boundingVolume and viewerRequestVolume from the tile's local coordinate system to the parent tile's coordinate system, or tileset's coordinate system in the case of the root tile.  transform does not apply to geometricError nor does it apply any volume property when the volume is a region, which is defined in WGS84 / EPSG:4326 coordinates.",
+            "description" : "A floating-point 4x4 affine transformation matrix, stored in column-major order, that transforms the tile's content--i.e., its features as well as content.boundingVolume, boundingVolume, and viewerRequestVolume--from the tile's local coordinate system to the parent tile's coordinate system, or, in the case of a root tile, from the tile's local coordinate system to the tileset's coordinate system.  transform does not apply to geometricError, nor does it apply any volume property when the volume is a region, defined in EPSG:4979 coordinates.",
             "items" : {
                 "type": "number"
             },
@@ -39,11 +39,17 @@
         },
         "children" : {
             "type" : "array",
-            "description" : "An array of objects that define child tiles. Each child tile has a box fully enclosed by its parent tile's box and, generally, a geometricError less than its parent tile's geometricError. For leaf tiles, the length of this array is zero, and children may not be defined.",
+            "description" : "An array of objects that define child tiles. Each child tile content is fully enclosed by its parent tile's bounding volume and, generally, has a geometricError less than its parent tile's geometricError. For leaf tiles, the length of this array is zero, and children may not be defined.",
             "items" : {
                 "$ref" : "tile.schema.json"
             },
             "uniqueItems" : true
+        },
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
     "required" : ["boundingVolume", "geometricError"],

--- a/validator/specs/data/schema/tileset.schema.json
+++ b/validator/specs/data/schema/tileset.schema.json
@@ -10,20 +10,43 @@
         },
         "properties" : {
             "description": "A dictionary object of metadata about per-feature properties.",
-            "patternProperties" : {
-                ".*": {
-                    "$ref": "properties.schema.json"
-                }
+            "properties" : {},
+            "additionalProperties" : {
+                "$ref" : "properties.schema.json"
             }
         },
         "geometricError" : {
             "type" : "number",
-            "description" : "The error, in meters, introduced if this tileset is not rendered. At runtime, the geometric error is used to compute Screen-Space Error (SSE), i.e., the error measured in pixels.",
+            "description" : "The error, in meters, introduced if this tileset is not rendered. At runtime, the geometric error is used to compute screen space error (SSE), i.e., the error measured in pixels.",
             "minimum" : 0
         },
         "root" : {
-            "description" : "The root node.",
+            "description" : "The root tile.",
             "$ref" : "tile.schema.json"
+        },
+        "extensionsUsed": {
+            "type": "array",
+            "description": "Names of 3D Tiles extensions used somewhere in this tileset.",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "minItems": 1
+        },
+        "extensionsRequired": {
+            "type": "array",
+            "description": "Names of 3D Tiles extensions required to properly load this tileset.",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "minItems": 1
+        },
+        "extensions" : {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
         }
     },
     "required" : ["asset", "geometricError", "root"],


### PR DESCRIPTION
Should be considered a draft, but seems to work for the cases I've tried.

Using the js version of glTF-Validator avoids the requirement to have Dart SDK installed, all that's needed is 'npm install'.